### PR TITLE
docs: add repository community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Report a reproducible bug in the firmware, docs, tooling, or setup flow.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+        Please do not use this form for security vulnerabilities. Use the private security reporting path instead.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
+      placeholder: A short description of the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Please provide the smallest reliable sequence that reproduces the issue.
+      placeholder: |
+        1. Flash firmware
+        2. Open setup
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: What actually happened?
+    validations:
+      required: true
+  - type: input
+    id: hardware
+    attributes:
+      label: Hardware
+      description: Controller board, machine model, and any other relevant hardware details.
+      placeholder: JC3636K718-style ESP32-S3 controller, Linea Micra, ...
+  - type: input
+    id: firmware
+    attributes:
+      label: Firmware version or commit
+      description: Tag, branch, or commit SHA if known.
+      placeholder: main @ 44b287a
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant serial logs, screenshots, or links here.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/kaspizzo/lamarzocco/security
+    about: Please report security issues privately and do not open a public issue.
+  - name: Project documentation
+    url: https://github.com/kaspizzo/lamarzocco/blob/main/README.md
+    about: Check the README and controller docs before opening a new issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest a new capability or an improvement to the controller, docs, or tooling.
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement.
+        Please keep the request concrete and explain the user value.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or missing capability
+      description: What is the current limitation?
+      placeholder: I cannot currently...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see instead?
+      placeholder: The controller should...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any workaround or alternative approach you already considered.
+      placeholder: Today I work around this by...
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add screenshots, references, machine details, or related links if useful.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+- describe the change briefly
+- explain the user-facing or technical impact
+
+## Testing
+
+- [ ] not run
+- [ ] build only
+- [ ] tested on hardware
+- [ ] docs only
+
+Describe the exact checks or manual test steps you performed.
+
+## Risks
+
+- note any known limitations, follow-up work, or migration concerns
+
+## Related
+
+- issue:
+- docs:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,120 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in this
+project and our community a harassment-free experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- demonstrating empathy and kindness toward other people
+- being respectful of differing opinions, viewpoints, and experiences
+- giving and gracefully accepting constructive feedback
+- accepting responsibility and apologizing to those affected by our mistakes
+- focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- the use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- trolling, insulting or derogatory comments, and personal or political attacks
+- public or private harassment
+- publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and also applies when
+an individual is officially representing the project in public spaces.
+Examples of representing our project include using an official project email
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer via GitHub at <https://github.com/kaspizzo>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All maintainers are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1,
+available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by Mozilla's code of conduct
+enforcement ladder at
+<https://github.com/mozilla/diversity>.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+This repository is currently maintained as a single rolling code line.
+
+| Version / Branch | Supported |
+| --- | --- |
+| `main` | Yes |
+| tagged releases | Best effort only |
+| older commits and unpublished branches | No |
+
+Security fixes are applied to the latest code on `main`.
+There is currently no separate long-term support branch.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues, pull requests, or discussions.
+
+Use one of these private paths instead:
+
+1. If GitHub private vulnerability reporting is enabled for this repository, use the `Security` tab and the `Report a vulnerability` flow.
+2. Otherwise, contact the maintainer privately via GitHub: <https://github.com/kaspizzo>
+
+When reporting a vulnerability, please include:
+
+- a short summary of the issue
+- the affected component or file
+- steps to reproduce, if available
+- impact and any suggested mitigation
+
+I will try to acknowledge valid reports promptly and coordinate a fix before public disclosure.


### PR DESCRIPTION
## Summary

Adds the missing public repository community-health files:

- `SECURITY.md`
- `CODE_OF_CONDUCT.md`
- issue template config with blank issues disabled
- bug report and feature request issue forms
- pull request template

## Why

These files improve the repository's public-project baseline and support the GitHub community profile and security reporting flow.

## Notes

- `main` is protected by a ruleset, so this change is opened as a pull request.
- No code or firmware behavior changed.