### PR TITLE
Add controller power status and setup fixes

### DIFF
--- a/firmware/esp32/main/CMakeLists.txt
+++ b/firmware/esp32/main/CMakeLists.txt
@@ -5,6 +5,7 @@ idf_component_register(
     "board_display.c"
     "board_haptic.c"
     "board_leds.c"
+    "board_power.c"
     "cloud_api.c"
     "cloud_auth.c"
     "cloud_dashboard.c"
@@ -34,6 +35,8 @@ idf_component_register(
     bt
     mdns
     led_strip
+    esp_adc
+    esp_driver_usb_serial_jtag
     esp_http_client
     esp_driver_ledc
     esp_driver_rmt

--- a/firmware/esp32/main/app_main.c
+++ b/firmware/esp32/main/app_main.c
@@ -13,6 +13,7 @@
 #include "board_display.h"
 #include "board_haptic.h"
 #include "board_leds.h"
+#include "board_power.h"
 #include "controller_runtime.h"
 #include "controller_ui.h"
 #include "input.h"
@@ -122,6 +123,7 @@ void app_main(void) {
   ESP_ERROR_CHECK(lm_ctrl_backlight_on());
   ESP_ERROR_CHECK(lm_ctrl_wifi_init());
   ESP_ERROR_CHECK(lm_ctrl_machine_link_init(&machine_link_deps));
+  ESP_ERROR_CHECK(lm_ctrl_power_init());
   if (lm_ctrl_leds_init() != ESP_OK) {
     ESP_LOGW(TAG, "LED ring init failed");
   }
@@ -148,6 +150,7 @@ void app_main(void) {
     }
 
     lm_ctrl_runtime_handle_wifi_status_change(&runtime, &needs_render);
+    lm_ctrl_runtime_handle_power_status_change(&runtime, &needs_render);
     lm_ctrl_runtime_handle_machine_status_change(&runtime, &needs_render);
     lm_ctrl_runtime_handle_preset_change(&runtime, &needs_render);
     lm_ctrl_runtime_tick(&runtime, &needs_render);

--- a/firmware/esp32/main/board_config.h
+++ b/firmware/esp32/main/board_config.h
@@ -34,6 +34,15 @@
 #define LM_CTRL_KNOB_DIRECTION (-1)
 #define LM_CTRL_ENCODER_ENABLED 1
 
+/** Optional local battery telemetry exposed by the controller board. */
+#define LM_CTRL_BATTERY_ADC_GPIO GPIO_NUM_6
+/* JC3636K718 v1.3 routes ETA6003 STAT only to the charge LED, not to the ESP32. */
+#define LM_CTRL_BATTERY_CHARGE_GPIO GPIO_NUM_NC
+#define LM_CTRL_BATTERY_CHARGE_ACTIVE_LEVEL 0
+#define LM_CTRL_BATTERY_SAMPLE_INTERVAL_MS 30000UL
+#define LM_CTRL_BATTERY_VOLTAGE_DIVIDER 3.0f
+#define LM_CTRL_BATTERY_LOW_PERCENT 20
+
 /** WS2812 LED ring on the controller face. */
 #define LM_CTRL_LED_RING_GPIO GPIO_NUM_0
 #define LM_CTRL_LED_RING_COUNT 13

--- a/firmware/esp32/main/board_leds.c
+++ b/firmware/esp32/main/board_leds.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "driver/gpio.h"
 #include "esp_check.h"
 #include "esp_log.h"
 #include "esp_timer.h"
@@ -143,4 +144,34 @@ void lm_ctrl_leds_tick(void) {
     (void)render_leds();
   }
   motion_was_active = motion_active;
+}
+
+esp_err_t lm_ctrl_leds_prepare_for_reset(void) {
+  esp_err_t ret = ESP_OK;
+
+  if (s_strip != NULL) {
+    for (int i = 0; i < LM_CTRL_LED_RING_COUNT; ++i) {
+      ret = led_strip_set_pixel(s_strip, i, 0, 0, 0);
+      if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to clear LED pixel %d before reset: %s", i, esp_err_to_name(ret));
+        break;
+      }
+    }
+    if (ret == ESP_OK) {
+      ret = led_strip_refresh(s_strip);
+      if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to flush LED clear before reset: %s", esp_err_to_name(ret));
+      }
+    }
+    if (led_strip_del(s_strip) != ESP_OK) {
+      ESP_LOGW(TAG, "Failed to release LED strip before reset");
+    }
+    s_strip = NULL;
+  }
+
+  s_status = LM_CTRL_LED_STATUS_IDLE;
+  s_motion_index = 0;
+  s_motion_until_us = 0;
+  ESP_RETURN_ON_ERROR(gpio_reset_pin(LM_CTRL_LED_RING_GPIO), TAG, "Failed to reset LED GPIO");
+  return ESP_OK;
 }

--- a/firmware/esp32/main/board_leds.h
+++ b/firmware/esp32/main/board_leds.h
@@ -18,3 +18,5 @@ esp_err_t lm_ctrl_leds_set_status(lm_ctrl_led_status_t status);
 esp_err_t lm_ctrl_leds_indicate_rotation(int delta_steps);
 /** Advance time-based LED animations from the main loop. */
 void lm_ctrl_leds_tick(void);
+/** Release GPIO0 before reboot so the board does not strap into download mode. */
+esp_err_t lm_ctrl_leds_prepare_for_reset(void);

--- a/firmware/esp32/main/board_power.c
+++ b/firmware/esp32/main/board_power.c
@@ -1,0 +1,365 @@
+#include "board_power.h"
+
+#include <string.h>
+
+#include "driver/gpio.h"
+#include "driver/usb_serial_jtag.h"
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_cali_scheme.h"
+#include "esp_adc/adc_oneshot.h"
+#include "esp_err.h"
+#include "esp_check.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+
+#include "board_config.h"
+
+static const char *TAG = "lm_power";
+static const int64_t LM_CTRL_POWER_SAMPLE_INTERVAL_US =
+  (int64_t)LM_CTRL_BATTERY_SAMPLE_INTERVAL_MS * 1000LL;
+
+typedef struct {
+  bool initialized;
+  bool available;
+  bool charging;
+  bool low;
+  bool usb_connected;
+  bool calibration_ready;
+  uint8_t level_percent;
+  uint32_t status_version;
+  adc_oneshot_unit_handle_t adc_handle;
+  adc_cali_handle_t cali_handle;
+  adc_unit_t adc_unit;
+  adc_channel_t adc_channel;
+  esp_timer_handle_t sample_timer;
+} lm_ctrl_power_state_t;
+
+static lm_ctrl_power_state_t s_power = {0};
+static portMUX_TYPE s_power_lock = portMUX_INITIALIZER_UNLOCKED;
+static bool s_gpio_isr_service_installed = false;
+
+static bool has_battery_adc(void) {
+  return LM_CTRL_BATTERY_ADC_GPIO != GPIO_NUM_NC;
+}
+
+static bool has_charging_gpio(void) {
+  return LM_CTRL_BATTERY_CHARGE_GPIO != GPIO_NUM_NC;
+}
+
+static bool battery_state_changed(bool available, bool charging, bool low, bool usb_connected, uint8_t level_percent) {
+  return s_power.available != available ||
+         s_power.charging != charging ||
+         s_power.low != low ||
+         s_power.usb_connected != usb_connected ||
+         s_power.level_percent != level_percent;
+}
+
+static uint8_t interpolate_level(int battery_mv, int lower_mv, int upper_mv, uint8_t lower_pct, uint8_t upper_pct) {
+  const int span_mv = upper_mv - lower_mv;
+  const int delta_mv = battery_mv - lower_mv;
+
+  if (span_mv <= 0) {
+    return lower_pct;
+  }
+
+  return (uint8_t)(lower_pct + ((delta_mv * (int)(upper_pct - lower_pct)) / span_mv));
+}
+
+static uint8_t battery_level_from_mv(int battery_mv) {
+  if (battery_mv <= 3300) {
+    return 0;
+  }
+  if (battery_mv < 3520) {
+    return interpolate_level(battery_mv, 3300, 3520, 0, 20);
+  }
+  if (battery_mv < 3640) {
+    return interpolate_level(battery_mv, 3520, 3640, 20, 40);
+  }
+  if (battery_mv < 3760) {
+    return interpolate_level(battery_mv, 3640, 3760, 40, 60);
+  }
+  if (battery_mv < 3880) {
+    return interpolate_level(battery_mv, 3760, 3880, 60, 80);
+  }
+  if (battery_mv < 4000) {
+    return interpolate_level(battery_mv, 3880, 4000, 80, 100);
+  }
+  return 100;
+}
+
+static bool read_charging_state(void) {
+  if (!has_charging_gpio()) {
+    return false;
+  }
+
+  return gpio_get_level(LM_CTRL_BATTERY_CHARGE_GPIO) == LM_CTRL_BATTERY_CHARGE_ACTIVE_LEVEL;
+}
+
+static bool read_usb_connected_state(void) {
+  return usb_serial_jtag_is_connected();
+}
+
+static void update_power_state(bool available, uint8_t level_percent, bool charging, bool usb_connected) {
+  const bool low = available && level_percent < LM_CTRL_BATTERY_LOW_PERCENT;
+
+  portENTER_CRITICAL(&s_power_lock);
+  if (battery_state_changed(available, charging, low, usb_connected, level_percent)) {
+    s_power.status_version++;
+  }
+  s_power.available = available;
+  s_power.charging = charging;
+  s_power.low = low;
+  s_power.usb_connected = usb_connected;
+  s_power.level_percent = level_percent;
+  portEXIT_CRITICAL(&s_power_lock);
+}
+
+static void sync_live_power_signals(void) {
+  bool available;
+  bool charging;
+  bool usb_connected;
+  bool low;
+  uint8_t level_percent;
+
+  charging = read_charging_state();
+  usb_connected = read_usb_connected_state();
+
+  portENTER_CRITICAL(&s_power_lock);
+  available = s_power.available;
+  level_percent = s_power.level_percent;
+  low = available && level_percent < LM_CTRL_BATTERY_LOW_PERCENT;
+  if (battery_state_changed(available, charging, low, usb_connected, level_percent)) {
+    s_power.status_version++;
+  }
+  s_power.charging = charging;
+  s_power.low = low;
+  s_power.usb_connected = usb_connected;
+  portEXIT_CRITICAL(&s_power_lock);
+}
+
+static esp_err_t read_battery_voltage_mv(int *battery_mv) {
+  int raw = 0;
+  int sensed_mv = 0;
+  esp_err_t ret;
+
+  if (battery_mv == NULL || s_power.adc_handle == NULL) {
+    return ESP_ERR_INVALID_ARG;
+  }
+
+  ret = adc_oneshot_read(s_power.adc_handle, s_power.adc_channel, &raw);
+  if (ret != ESP_OK) {
+    return ret;
+  }
+
+  if (s_power.calibration_ready && s_power.cali_handle != NULL) {
+    ret = adc_cali_raw_to_voltage(s_power.cali_handle, raw, &sensed_mv);
+    if (ret != ESP_OK) {
+      return ret;
+    }
+  } else {
+    sensed_mv = (raw * 3300) / 4095;
+  }
+
+  *battery_mv = (int)((float)sensed_mv * LM_CTRL_BATTERY_VOLTAGE_DIVIDER);
+  return ESP_OK;
+}
+
+static void sample_power_state(void) {
+  int battery_mv = 0;
+
+  if (read_battery_voltage_mv(&battery_mv) != ESP_OK) {
+    ESP_LOGW(TAG, "Battery ADC read failed");
+    return;
+  }
+
+  update_power_state(true, battery_level_from_mv(battery_mv), read_charging_state(), read_usb_connected_state());
+}
+
+static void sample_power_timer_cb(void *arg) {
+  (void)arg;
+  sample_power_state();
+}
+
+static void charging_gpio_isr_cb(void *arg) {
+  bool available;
+  bool charging;
+  bool usb_connected;
+  bool low;
+  uint8_t level_percent;
+
+  (void)arg;
+  if (!has_charging_gpio()) {
+    return;
+  }
+
+  charging = read_charging_state();
+  usb_connected = read_usb_connected_state();
+  portENTER_CRITICAL_ISR(&s_power_lock);
+  available = s_power.available;
+  level_percent = s_power.level_percent;
+  low = available && level_percent < LM_CTRL_BATTERY_LOW_PERCENT;
+  if (battery_state_changed(available, charging, low, usb_connected, level_percent)) {
+    s_power.status_version++;
+  }
+  s_power.charging = charging;
+  s_power.low = low;
+  s_power.usb_connected = usb_connected;
+  portEXIT_CRITICAL_ISR(&s_power_lock);
+}
+
+static esp_err_t init_charging_gpio(void) {
+  gpio_config_t config = {0};
+  unsigned charge_gpio = 0;
+  esp_err_t ret;
+
+  if (!has_charging_gpio()) {
+    ESP_LOGI(TAG, "Battery charge detect GPIO not configured");
+    return ESP_OK;
+  }
+
+  charge_gpio = (unsigned)(int)LM_CTRL_BATTERY_CHARGE_GPIO;
+  config.pin_bit_mask = 1ULL << charge_gpio;
+  config.mode = GPIO_MODE_INPUT;
+  config.pull_up_en = GPIO_PULLUP_DISABLE;
+  config.pull_down_en = GPIO_PULLDOWN_DISABLE;
+  config.intr_type = GPIO_INTR_ANYEDGE;
+
+  ret = gpio_config(&config);
+  if (ret != ESP_OK) {
+    return ret;
+  }
+
+  if (!s_gpio_isr_service_installed) {
+    ret = gpio_install_isr_service(0);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+      return ret;
+    }
+    s_gpio_isr_service_installed = true;
+  }
+
+  ret = gpio_isr_handler_add(LM_CTRL_BATTERY_CHARGE_GPIO, charging_gpio_isr_cb, NULL);
+  if (ret != ESP_OK) {
+    return ret;
+  }
+
+  ESP_LOGI(TAG, "Battery charge detect configured on GPIO %d", LM_CTRL_BATTERY_CHARGE_GPIO);
+  return ESP_OK;
+}
+
+static void init_calibration_if_available(adc_channel_t channel) {
+#if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
+  adc_cali_curve_fitting_config_t cali_config = {
+    .unit_id = s_power.adc_unit,
+    .chan = channel,
+    .atten = ADC_ATTEN_DB_12,
+    .bitwidth = ADC_BITWIDTH_DEFAULT,
+  };
+
+  if (adc_cali_create_scheme_curve_fitting(&cali_config, &s_power.cali_handle) == ESP_OK) {
+    s_power.calibration_ready = true;
+  } else {
+    ESP_LOGW(TAG, "ADC calibration unavailable, falling back to raw battery estimates");
+  }
+#else
+  (void)channel;
+#endif
+}
+
+esp_err_t lm_ctrl_power_init(void) {
+  adc_oneshot_unit_init_cfg_t unit_config = {0};
+  adc_oneshot_chan_cfg_t channel_config = {
+    .bitwidth = ADC_BITWIDTH_DEFAULT,
+    .atten = ADC_ATTEN_DB_12,
+  };
+  esp_timer_create_args_t timer_args = {
+    .callback = sample_power_timer_cb,
+    .arg = NULL,
+    .name = "lm_battery",
+  };
+  adc_unit_t adc_unit = ADC_UNIT_1;
+  adc_channel_t adc_channel = ADC_CHANNEL_0;
+  esp_err_t ret;
+
+  if (s_power.initialized) {
+    return ESP_OK;
+  }
+
+  if (!has_battery_adc()) {
+    s_power.initialized = true;
+    return ESP_OK;
+  }
+
+  ret = init_charging_gpio();
+  if (ret != ESP_OK) {
+    return ret;
+  }
+
+  ret = adc_oneshot_io_to_channel((int)LM_CTRL_BATTERY_ADC_GPIO, &adc_unit, &adc_channel);
+  if (ret != ESP_OK) {
+    return ret;
+  }
+
+  unit_config.unit_id = adc_unit;
+  unit_config.ulp_mode = ADC_ULP_MODE_DISABLE;
+  ret = adc_oneshot_new_unit(&unit_config, &s_power.adc_handle);
+  if (ret != ESP_OK) {
+    return ret;
+  }
+
+  ret = adc_oneshot_config_channel(s_power.adc_handle, adc_channel, &channel_config);
+  if (ret != ESP_OK) {
+    return ret;
+  }
+
+  s_power.adc_unit = adc_unit;
+  s_power.adc_channel = adc_channel;
+  init_calibration_if_available(adc_channel);
+
+  ret = esp_timer_create(&timer_args, &s_power.sample_timer);
+  if (ret != ESP_OK) {
+    return ret;
+  }
+
+  sample_power_state();
+  ret = esp_timer_start_periodic(s_power.sample_timer, LM_CTRL_POWER_SAMPLE_INTERVAL_US);
+  if (ret != ESP_OK) {
+    return ret;
+  }
+
+  s_power.initialized = true;
+  ESP_LOGI(
+    TAG,
+    "Battery monitor initialized on GPIO %d with %lu ms sampling",
+    LM_CTRL_BATTERY_ADC_GPIO,
+    (unsigned long)LM_CTRL_BATTERY_SAMPLE_INTERVAL_MS
+  );
+  return ESP_OK;
+}
+
+void lm_ctrl_power_get_info(lm_ctrl_power_info_t *info) {
+  if (info == NULL) {
+    return;
+  }
+
+  sync_live_power_signals();
+  memset(info, 0, sizeof(*info));
+  portENTER_CRITICAL(&s_power_lock);
+  info->available = s_power.available;
+  info->charging = s_power.charging;
+  info->low = s_power.low;
+  info->usb_connected = s_power.usb_connected;
+  info->level_percent = s_power.level_percent;
+  portEXIT_CRITICAL(&s_power_lock);
+}
+
+uint32_t lm_ctrl_power_status_version(void) {
+  uint32_t version;
+
+  sync_live_power_signals();
+  portENTER_CRITICAL(&s_power_lock);
+  version = s_power.status_version;
+  portEXIT_CRITICAL(&s_power_lock);
+
+  return version;
+}

--- a/firmware/esp32/main/board_power.h
+++ b/firmware/esp32/main/board_power.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  bool available;
+  bool charging;
+  bool low;
+  bool usb_connected;
+  uint8_t level_percent;
+} lm_ctrl_power_info_t;
+
+esp_err_t lm_ctrl_power_init(void);
+void lm_ctrl_power_get_info(lm_ctrl_power_info_t *info);
+uint32_t lm_ctrl_power_status_version(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/firmware/esp32/main/controller_runtime.c
+++ b/firmware/esp32/main/controller_runtime.c
@@ -15,6 +15,7 @@
 
 #include "board_haptic.h"
 #include "board_leds.h"
+#include "board_power.h"
 #include "machine_link.h"
 #include "machine_link_policy.h"
 #include "wifi_setup.h"
@@ -771,6 +772,7 @@ void lm_ctrl_runtime_bootstrap(lm_ctrl_runtime_t *runtime) {
   }
 
   runtime->last_wifi_status_version = lm_ctrl_wifi_status_version();
+  runtime->last_power_status_version = lm_ctrl_power_status_version();
   runtime->last_machine_status_version = lm_ctrl_machine_link_status_version();
   runtime->last_preset_version = ctrl_state_preset_version();
   maybe_request_cloud_probe(&runtime->last_cloud_probe_request_us);
@@ -961,6 +963,24 @@ void lm_ctrl_runtime_handle_wifi_status_change(lm_ctrl_runtime_t *runtime, bool 
   }
 }
 
+void lm_ctrl_runtime_handle_power_status_change(lm_ctrl_runtime_t *runtime, bool *needs_render) {
+  uint32_t power_status_version;
+
+  if (runtime == NULL) {
+    return;
+  }
+
+  power_status_version = lm_ctrl_power_status_version();
+  if (power_status_version == runtime->last_power_status_version) {
+    return;
+  }
+
+  runtime->last_power_status_version = power_status_version;
+  if (needs_render != NULL) {
+    *needs_render = true;
+  }
+}
+
 void lm_ctrl_runtime_handle_machine_status_change(lm_ctrl_runtime_t *runtime, bool *needs_render) {
   uint32_t machine_status_version;
 
@@ -1055,6 +1075,7 @@ const char *lm_ctrl_runtime_status(const lm_ctrl_runtime_t *runtime) {
 
 void lm_ctrl_runtime_build_ui_view(const lm_ctrl_runtime_t *runtime, lm_ctrl_ui_view_t *view) {
   lm_ctrl_wifi_info_t wifi_info = {0};
+  lm_ctrl_power_info_t power_info = {0};
   lm_ctrl_machine_link_info_t machine_info = {0};
 
   if (runtime == NULL || view == NULL) {
@@ -1063,11 +1084,16 @@ void lm_ctrl_runtime_build_ui_view(const lm_ctrl_runtime_t *runtime, lm_ctrl_ui_
 
   memset(view, 0, sizeof(*view));
   lm_ctrl_wifi_get_info(&wifi_info);
+  lm_ctrl_power_get_info(&power_info);
   lm_ctrl_machine_link_get_info(&machine_info);
 
   view->language = wifi_info.language;
   view->wifi_visible = wifi_info.sta_connected || wifi_info.sta_connecting;
   view->wifi_connected = wifi_info.sta_connected;
+  view->usb_visible = power_info.usb_connected;
+  view->battery_visible = power_info.low || power_info.charging;
+  view->battery_charging = power_info.charging;
+  view->battery_low = power_info.low;
   view->heat_visible =
     wifi_info.heat_display_enabled &&
     runtime->heat_state.heating &&

--- a/firmware/esp32/main/controller_runtime.h
+++ b/firmware/esp32/main/controller_runtime.h
@@ -40,6 +40,7 @@ typedef struct {
   ctrl_state_t state;
   char status[256];
   uint32_t last_wifi_status_version;
+  uint32_t last_power_status_version;
   uint32_t last_machine_status_version;
   uint32_t last_preset_version;
   int64_t last_cloud_probe_request_us;
@@ -56,6 +57,7 @@ void lm_ctrl_runtime_init(lm_ctrl_runtime_t *runtime);
 void lm_ctrl_runtime_bootstrap(lm_ctrl_runtime_t *runtime);
 void lm_ctrl_runtime_handle_input_event(lm_ctrl_runtime_t *runtime, const lm_ctrl_input_event_t *event, bool *needs_render);
 void lm_ctrl_runtime_handle_wifi_status_change(lm_ctrl_runtime_t *runtime, bool *needs_render);
+void lm_ctrl_runtime_handle_power_status_change(lm_ctrl_runtime_t *runtime, bool *needs_render);
 void lm_ctrl_runtime_handle_machine_status_change(lm_ctrl_runtime_t *runtime, bool *needs_render);
 void lm_ctrl_runtime_handle_preset_change(lm_ctrl_runtime_t *runtime, bool *needs_render);
 void lm_ctrl_runtime_tick(lm_ctrl_runtime_t *runtime, bool *needs_render);

--- a/firmware/esp32/main/controller_ui.c
+++ b/firmware/esp32/main/controller_ui.c
@@ -22,6 +22,7 @@ static const lv_color_t COLOR_TEXT = LV_COLOR_MAKE(0xF4, 0xEF, 0xE7);
 static const lv_color_t COLOR_MUTED = LV_COLOR_MAKE(0xB7, 0xA0, 0x8B);
 static const lv_color_t COLOR_ACTIVE = LV_COLOR_MAKE(0xFF, 0xC6, 0x85);
 static const lv_color_t COLOR_BUTTON = LV_COLOR_MAKE(0x3A, 0x2A, 0x21);
+static const char *BATTERY_CHARGING_SYMBOL = LV_SYMBOL_BATTERY_FULL LV_SYMBOL_CHARGE;
 
 static const ctrl_focus_t MAIN_PAGE_ORDER[LM_CTRL_UI_MAIN_PAGE_COUNT] = {
   CTRL_FOCUS_TEMPERATURE,
@@ -637,29 +638,71 @@ static void render_main_screen(
 }
 
 static void render_connection_icons(lm_ctrl_ui_t *ui, const lm_ctrl_ui_view_t *view) {
+  typedef struct {
+    lv_obj_t *obj;
+    const char *symbol;
+    lv_color_t color;
+  } icon_slot_t;
+  icon_slot_t slots[5];
+  size_t visible_count = 0;
+  const int step = 34;
+  const int y = 48;
+
   if (ui == NULL || view == NULL) {
     return;
   }
 
+  set_hidden(ui->wifi_icon, true);
+  set_hidden(ui->usb_icon, true);
+  set_hidden(ui->battery_icon, true);
+  set_hidden(ui->heat_icon, true);
+  set_hidden(ui->ble_icon, true);
+
   if (view->wifi_visible) {
-    set_hidden(ui->wifi_icon, false);
-    set_label_text(ui->wifi_icon, LV_SYMBOL_WIFI, view->wifi_connected ? COLOR_ACTIVE : COLOR_MUTED);
-  } else {
-    set_hidden(ui->wifi_icon, true);
+    slots[visible_count++] = (icon_slot_t){
+      .obj = ui->wifi_icon,
+      .symbol = LV_SYMBOL_WIFI,
+      .color = view->wifi_connected ? COLOR_ACTIVE : COLOR_MUTED,
+    };
   }
 
   if (view->heat_visible) {
-    set_hidden(ui->heat_icon, false);
-    set_label_text(ui->heat_icon, LV_SYMBOL_CHARGE, COLOR_ACTIVE);
-  } else {
-    set_hidden(ui->heat_icon, true);
+    slots[visible_count++] = (icon_slot_t){
+      .obj = ui->heat_icon,
+      .symbol = LV_SYMBOL_CHARGE,
+      .color = COLOR_ACTIVE,
+    };
   }
 
   if (view->ble_visible) {
-    set_hidden(ui->ble_icon, false);
-    set_label_text(ui->ble_icon, LV_SYMBOL_BLUETOOTH, view->ble_authenticated ? COLOR_ACTIVE : COLOR_MUTED);
-  } else {
-    set_hidden(ui->ble_icon, true);
+    slots[visible_count++] = (icon_slot_t){
+      .obj = ui->ble_icon,
+      .symbol = LV_SYMBOL_BLUETOOTH,
+      .color = view->ble_authenticated ? COLOR_ACTIVE : COLOR_MUTED,
+    };
+  }
+
+  if (view->usb_visible) {
+    slots[visible_count++] = (icon_slot_t){
+      .obj = ui->usb_icon,
+      .symbol = LV_SYMBOL_USB,
+      .color = COLOR_ACTIVE,
+    };
+  }
+
+  if (view->battery_visible) {
+    slots[visible_count++] = (icon_slot_t){
+      .obj = ui->battery_icon,
+      .symbol = view->battery_charging ? BATTERY_CHARGING_SYMBOL : LV_SYMBOL_BATTERY_EMPTY,
+      .color = COLOR_ACTIVE,
+    };
+  }
+
+  for (size_t i = 0; i < visible_count; ++i) {
+    const int x = ((int)i * step) - (((int)visible_count - 1) * step / 2);
+    set_hidden(slots[i].obj, false);
+    set_label_text(slots[i].obj, slots[i].symbol, slots[i].color);
+    lv_obj_align(slots[i].obj, LV_ALIGN_TOP_MID, x, y);
   }
 }
 
@@ -837,16 +880,26 @@ esp_err_t lm_ctrl_ui_init(
 
   ui->wifi_icon = lv_label_create(ui->screen);
   lv_obj_set_style_text_font(ui->wifi_icon, &lv_font_montserrat_14, 0);
-  lv_obj_align(ui->wifi_icon, LV_ALIGN_TOP_MID, -24, 48);
+  lv_obj_align(ui->wifi_icon, LV_ALIGN_TOP_MID, -68, 48);
+
+  ui->usb_icon = lv_label_create(ui->screen);
+  lv_obj_set_style_text_font(ui->usb_icon, &lv_font_montserrat_14, 0);
+  lv_obj_align(ui->usb_icon, LV_ALIGN_TOP_MID, 34, 48);
+  set_hidden(ui->usb_icon, true);
+
+  ui->battery_icon = lv_label_create(ui->screen);
+  lv_obj_set_style_text_font(ui->battery_icon, &lv_font_montserrat_14, 0);
+  lv_obj_align(ui->battery_icon, LV_ALIGN_TOP_MID, 68, 48);
+  set_hidden(ui->battery_icon, true);
 
   ui->heat_icon = lv_label_create(ui->screen);
   lv_obj_set_style_text_font(ui->heat_icon, &lv_font_montserrat_14, 0);
-  lv_obj_align(ui->heat_icon, LV_ALIGN_TOP_MID, 0, 48);
+  lv_obj_align(ui->heat_icon, LV_ALIGN_TOP_MID, -34, 48);
   set_hidden(ui->heat_icon, true);
 
   ui->ble_icon = lv_label_create(ui->screen);
   lv_obj_set_style_text_font(ui->ble_icon, &lv_font_montserrat_14, 0);
-  lv_obj_align(ui->ble_icon, LV_ALIGN_TOP_MID, 24, 48);
+  lv_obj_align(ui->ble_icon, LV_ALIGN_TOP_MID, 0, 48);
 
   ui->page_label = lv_label_create(ui->screen);
   lv_obj_set_style_text_font(ui->page_label, &lv_font_montserrat_14, 0);
@@ -1021,6 +1074,8 @@ esp_err_t lm_ctrl_ui_init(
   lv_obj_move_foreground(ui->title_text);
   lv_obj_move_foreground(ui->title_image);
   lv_obj_move_foreground(ui->wifi_icon);
+  lv_obj_move_foreground(ui->usb_icon);
+  lv_obj_move_foreground(ui->battery_icon);
   lv_obj_move_foreground(ui->heat_icon);
   lv_obj_move_foreground(ui->ble_icon);
   lv_obj_move_foreground(ui->page_label);

--- a/firmware/esp32/main/controller_ui.h
+++ b/firmware/esp32/main/controller_ui.h
@@ -19,6 +19,10 @@ typedef struct {
   ctrl_language_t language;
   bool wifi_visible;
   bool wifi_connected;
+  bool usb_visible;
+  bool battery_visible;
+  bool battery_charging;
+  bool battery_low;
   bool heat_visible;
   bool heat_arc_visible;
   bool steam_heat_eta_visible;
@@ -65,6 +69,8 @@ struct lm_ctrl_ui_s {
   lv_obj_t *title_text;
   lv_obj_t *title_image;
   lv_obj_t *wifi_icon;
+  lv_obj_t *usb_icon;
+  lv_obj_t *battery_icon;
   lv_obj_t *heat_icon;
   lv_obj_t *ble_icon;
   lv_obj_t *heat_arc;

--- a/firmware/esp32/main/wifi_setup.c
+++ b/firmware/esp32/main/wifi_setup.c
@@ -29,6 +29,7 @@
 #include "lwip/sockets.h"
 #include "cloud_live_updates.h"
 #include "cloud_session.h"
+#include "board_leds.h"
 #include "controller_settings.h"
 #include "setup_portal_routes.h"
 #include "storage_security.h"
@@ -119,6 +120,10 @@ static void delayed_restart_task(void *arg) {
   const int delay_ms = (int)(intptr_t)arg;
 
   vTaskDelay(pdMS_TO_TICKS(delay_ms > 0 ? delay_ms : 250));
+  if (lm_ctrl_leds_prepare_for_reset() != ESP_OK) {
+    ESP_LOGW(TAG, "Failed to release LED ring before restart");
+  }
+  vTaskDelay(pdMS_TO_TICKS(20));
   esp_restart();
 }
 
@@ -126,6 +131,7 @@ static esp_err_t update_mdns_hostname(void);
 static esp_err_t start_dns_server(void);
 static void stop_dns_server(void);
 static esp_err_t disable_setup_ap(void);
+static esp_err_t restart_setup_portal_after_network_reset(void);
 
 static void fill_portal_ssid_locked(void) {
   uint8_t mac[6] = {0};
@@ -139,8 +145,8 @@ static void fill_portal_ssid_locked(void) {
 }
 
 static esp_err_t ensure_portal_password(void) {
-  char random_suffix[17];
-  char generated_password[65];
+  char random_suffix[9];
+  char generated_password[9];
   bool needs_password = false;
 
   lock_state();
@@ -150,8 +156,8 @@ static esp_err_t ensure_portal_password(void) {
     return ESP_OK;
   }
 
-  fill_random_hex(random_suffix, sizeof(random_suffix), 8);
-  snprintf(generated_password, sizeof(generated_password), "LMCTRL-%s", random_suffix);
+  fill_random_hex(random_suffix, sizeof(random_suffix), 4);
+  snprintf(generated_password, sizeof(generated_password), "%s", random_suffix);
   secure_zero(random_suffix, sizeof(random_suffix));
   ESP_RETURN_ON_ERROR(lm_ctrl_settings_save_portal_password(generated_password), TAG, "Failed to persist setup AP password");
   secure_zero(generated_password, sizeof(generated_password));
@@ -245,7 +251,7 @@ esp_err_t lm_ctrl_wifi_reset_network(void) {
     return ret;
   }
 
-  return lm_ctrl_wifi_schedule_reboot();
+  return restart_setup_portal_after_network_reset();
 }
 
 esp_err_t lm_ctrl_wifi_factory_reset(void) {
@@ -281,6 +287,44 @@ static esp_err_t configure_ap(void) {
 
   ESP_RETURN_ON_ERROR(esp_wifi_set_mode(WIFI_MODE_APSTA), TAG, "Failed to set Wi-Fi mode for AP");
   ESP_RETURN_ON_ERROR(esp_wifi_set_config(WIFI_IF_AP, &ap_config), TAG, "Failed to configure setup AP");
+  return ESP_OK;
+}
+
+static esp_err_t restart_setup_portal_after_network_reset(void) {
+  if (!s_state.initialized || !s_state.wifi_started) {
+    return ESP_ERR_INVALID_STATE;
+  }
+
+  esp_err_t ret = esp_wifi_disconnect();
+  if (ret != ESP_OK && ret != ESP_ERR_WIFI_NOT_STARTED && ret != ESP_ERR_WIFI_CONN) {
+    return ret;
+  }
+
+  ret = esp_wifi_set_mode(WIFI_MODE_STA);
+  if (ret != ESP_OK) {
+    return ret;
+  }
+
+  lock_state();
+  s_state.portal_running = false;
+  s_state.sta_connecting = false;
+  s_state.sta_connected = false;
+  s_state.sta_ip[0] = '\0';
+  mark_status_dirty_locked();
+  unlock_state();
+  stop_dns_server();
+
+  ESP_RETURN_ON_ERROR(ensure_portal_password(), TAG, "Failed to recreate setup AP password");
+  ESP_RETURN_ON_ERROR(configure_ap(), TAG, "Failed to reconfigure setup AP after network reset");
+  ESP_RETURN_ON_ERROR(lm_ctrl_setup_portal_start_http_server(), TAG, "Failed to ensure setup portal web server");
+
+  lock_state();
+  s_state.portal_running = true;
+  mark_status_dirty_locked();
+  unlock_state();
+
+  ESP_RETURN_ON_ERROR(start_dns_server(), TAG, "Failed to restart captive DNS after network reset");
+  ESP_LOGI(TAG, "Network reset completed; setup portal resumed on http://192.168.4.1");
   return ESP_OK;
 }
 


### PR DESCRIPTION
## Summary
- add controller power status handling for low-battery and USB-connected indicators
- center the header status icon group and keep USB as a separate icon
- shorten the setup AP password to 8 characters and restore the previous setup-screen spacing
- make network reset restart setup services in-place instead of depending on a reboot
- guard the LED ring / GPIO0 path before app-triggered restarts
- fix the generated portal-password bug that could cause a boot loop after reset

## Validation
- `./dev.sh build`
- repeated `./dev.sh flash` on hardware
- on-device setup and reset debugging over serial logs

## Notes
- vendor reference bundle `JC3636K718_knob_EN(2)/` is intentionally not included in this PR