### PR TITLE
[codex] Tighten controller status icon spacing

### DIFF
--- a/firmware/esp32/main/controller_ui.c
+++ b/firmware/esp32/main/controller_ui.c
@@ -645,7 +645,7 @@ static void render_connection_icons(lm_ctrl_ui_t *ui, const lm_ctrl_ui_view_t *v
   } icon_slot_t;
   icon_slot_t slots[5];
   size_t visible_count = 0;
-  const int step = 34;
+  const int step = 28;
   const int y = 48;
 
   if (ui == NULL || view == NULL) {


### PR DESCRIPTION
## Summary
- reduce the centered header status icon spacing from 34px to 28px
- keep the centered-group behavior so icons still expand outward as more indicators appear
- preserve the existing power, USB, and setup changes already merged on `main`

## Why
The new centered icon layout left the visual gap between the Wi-Fi and USB icons feeling wider than the previous Wi-Fi/Bluetooth spacing. This follow-up tightens the group without reverting the centered layout.

## Validation
- `./dev.sh build`
- flashed and visually checked on device

## Scope
This PR contains only the status-icon spacing adjustment in `controller_ui.c`.