### PR TITLE
[codex] Unify warmup ETA display

### DIFF
--- a/firmware/esp32/main/controller_runtime.c
+++ b/firmware/esp32/main/controller_runtime.c
@@ -157,14 +157,12 @@ static bool initialize_heat_state_deadline(
 static void sync_heat_state(lm_ctrl_runtime_t *runtime) {
   lm_ctrl_machine_heat_info_t heat_info = {0};
   bool have_machine_eta = false;
-  bool have_steam_eta = false;
 
   if (runtime == NULL) {
     return;
   }
   if (!should_show_heat_display()) {
     reset_heat_state(&runtime->heat_state);
-    reset_heat_state(&runtime->steam_heat_state);
     clear_heat_refresh(&runtime->heat_refresh);
     return;
   }
@@ -173,16 +171,11 @@ static void sync_heat_state(lm_ctrl_runtime_t *runtime) {
 
   if (!heat_info.available || !heat_info.heating) {
     reset_heat_state(&runtime->heat_state);
-    reset_heat_state(&runtime->steam_heat_state);
     clear_heat_refresh(&runtime->heat_refresh);
     return;
   }
 
   runtime->heat_state.heating = heat_info.heating;
-  runtime->steam_heat_state.heating = heat_info.steam_heating;
-  if (!heat_info.steam_heating) {
-    reset_heat_state(&runtime->steam_heat_state);
-  }
   if (heat_info.eta_available && heat_info.ready_epoch_ms > 0) {
     have_machine_eta = initialize_heat_state_deadline(
       &runtime->heat_state,
@@ -190,14 +183,7 @@ static void sync_heat_state(lm_ctrl_runtime_t *runtime) {
       heat_info.ready_epoch_ms
     );
   }
-  if (heat_info.steam_eta_available && heat_info.steam_ready_epoch_ms > 0) {
-    have_steam_eta = initialize_heat_state_deadline(
-      &runtime->steam_heat_state,
-      heat_info.observed_epoch_ms,
-      heat_info.steam_ready_epoch_ms
-    );
-  }
-  if (have_machine_eta && (!heat_info.steam_heating || have_steam_eta)) {
+  if (have_machine_eta) {
     clear_heat_refresh(&runtime->heat_refresh);
   }
 }
@@ -686,13 +672,10 @@ static void maybe_request_fast_heat_refresh(lm_ctrl_runtime_t *runtime) {
   lm_ctrl_wifi_get_info(&wifi_info);
   if (!wifi_info.heat_display_enabled) {
     reset_heat_state(&runtime->heat_state);
-    reset_heat_state(&runtime->steam_heat_state);
     clear_heat_refresh(&runtime->heat_refresh);
     return;
   }
-  if (runtime->state.values.standby_on ||
-      (runtime->heat_state.deadline_local_us > 0 &&
-       (!runtime->steam_heat_state.heating || runtime->steam_heat_state.deadline_local_us > 0))) {
+  if (runtime->state.values.standby_on || runtime->heat_state.deadline_local_us > 0) {
     clear_heat_refresh(&runtime->heat_refresh);
     return;
   }
@@ -724,7 +707,6 @@ void lm_ctrl_runtime_init(lm_ctrl_runtime_t *runtime) {
 
   memset(runtime, 0, sizeof(*runtime));
   reset_heat_state(&runtime->heat_state);
-  reset_heat_state(&runtime->steam_heat_state);
   ctrl_state_init(&runtime->state);
   if (ctrl_state_load(&runtime->state) != ESP_OK) {
     ESP_LOGW(TAG, "Falling back to default controller values");
@@ -840,11 +822,9 @@ void lm_ctrl_runtime_handle_input_event(
         }
         if (event->focus == CTRL_FOCUS_STANDBY && runtime->state.values.standby_on) {
           reset_heat_state(&runtime->heat_state);
-          reset_heat_state(&runtime->steam_heat_state);
           clear_heat_refresh(&runtime->heat_refresh);
         } else if (waking_from_standby) {
           reset_heat_state(&runtime->heat_state);
-          reset_heat_state(&runtime->steam_heat_state);
           arm_heat_refresh(&runtime->heat_refresh, HEAT_REFRESH_INITIAL_DELAY_US);
         }
       }
@@ -1019,8 +999,6 @@ void lm_ctrl_runtime_handle_preset_change(lm_ctrl_runtime_t *runtime, bool *need
 void lm_ctrl_runtime_tick(lm_ctrl_runtime_t *runtime, bool *needs_render) {
   int32_t remaining_s;
   int32_t progress_permille;
-  int32_t steam_remaining_s;
-  int32_t steam_progress_permille;
 
   if (runtime == NULL) {
     return;
@@ -1033,24 +1011,12 @@ void lm_ctrl_runtime_tick(lm_ctrl_runtime_t *runtime, bool *needs_render) {
   maybe_flush_delayed_machine_send(&runtime->state, &runtime->delayed_machine_send, &runtime->local_value_hold);
   remaining_s = heat_state_remaining_seconds(&runtime->heat_state);
   progress_permille = (int32_t)heat_state_progress_permille(&runtime->heat_state);
-  steam_remaining_s = heat_state_remaining_seconds(&runtime->steam_heat_state);
-  steam_progress_permille = (int32_t)heat_state_progress_permille(&runtime->steam_heat_state);
   if (runtime->heat_state.heating &&
       runtime->heat_state.deadline_local_us > 0 &&
       (remaining_s != runtime->heat_state.last_rendered_remaining_s ||
        progress_permille != runtime->heat_state.last_rendered_progress_permille)) {
     runtime->heat_state.last_rendered_remaining_s = remaining_s;
     runtime->heat_state.last_rendered_progress_permille = progress_permille;
-    if (needs_render != NULL) {
-      *needs_render = true;
-    }
-  }
-  if (runtime->steam_heat_state.heating &&
-      runtime->steam_heat_state.deadline_local_us > 0 &&
-      (steam_remaining_s != runtime->steam_heat_state.last_rendered_remaining_s ||
-       steam_progress_permille != runtime->steam_heat_state.last_rendered_progress_permille)) {
-    runtime->steam_heat_state.last_rendered_remaining_s = steam_remaining_s;
-    runtime->steam_heat_state.last_rendered_progress_permille = steam_progress_permille;
     if (needs_render != NULL) {
       *needs_render = true;
     }
@@ -1095,10 +1061,6 @@ void lm_ctrl_runtime_build_ui_view(const lm_ctrl_runtime_t *runtime, lm_ctrl_ui_
     wifi_info.heat_display_enabled &&
     runtime->heat_state.duration_us > 0 &&
     view->heat_visible;
-  view->steam_heat_eta_visible =
-    wifi_info.heat_display_enabled &&
-    runtime->steam_heat_state.heating &&
-    heat_state_remaining_us(&runtime->steam_heat_state) > 0;
   view->ble_visible = machine_info.connected || machine_info.authenticated;
   view->ble_authenticated = machine_info.authenticated;
   view->readable_mask = access.readable_mask;
@@ -1111,16 +1073,6 @@ void lm_ctrl_runtime_build_ui_view(const lm_ctrl_runtime_t *runtime, lm_ctrl_ui_
     snprintf(
       view->heat_eta_text,
       sizeof(view->heat_eta_text),
-      "%d:%02d",
-      (int)(remaining_s / 60),
-      (int)(remaining_s % 60)
-    );
-  }
-  if (view->steam_heat_eta_visible) {
-    int32_t remaining_s = heat_state_remaining_seconds(&runtime->steam_heat_state);
-    snprintf(
-      view->steam_heat_eta_text,
-      sizeof(view->steam_heat_eta_text),
       "%d:%02d",
       (int)(remaining_s / 60),
       (int)(remaining_s % 60)

--- a/firmware/esp32/main/controller_runtime.h
+++ b/firmware/esp32/main/controller_runtime.h
@@ -49,7 +49,6 @@ typedef struct {
   lm_ctrl_runtime_local_value_hold_t local_value_hold;
   lm_ctrl_runtime_delayed_machine_send_t delayed_machine_send;
   lm_ctrl_runtime_heat_state_t heat_state;
-  lm_ctrl_runtime_heat_state_t steam_heat_state;
   lm_ctrl_runtime_heat_refresh_t heat_refresh;
 } lm_ctrl_runtime_t;
 

--- a/firmware/esp32/main/controller_ui.c
+++ b/firmware/esp32/main/controller_ui.c
@@ -376,12 +376,12 @@ static void format_main_value(
         "%s",
         ctrl_steam_level_label(state->values.steam_level)
       );
-      if (view != NULL && view->steam_heat_eta_visible && view->steam_heat_eta_text[0] != '\0') {
+      if (view != NULL && view->heat_arc_visible && view->heat_eta_text[0] != '\0') {
         snprintf(
           hint,
           hint_size,
-          language == CTRL_LANGUAGE_DE ? "Dampf heizt auf.\nBereit in %s." : "Steam heating.\nReady in %s.",
-          view->steam_heat_eta_text
+          language == CTRL_LANGUAGE_DE ? "Aufheizen laeuft.\nBereit in %s." : "Heating up.\nReady in %s.",
+          view->heat_eta_text
         );
       } else {
         snprintf(

--- a/firmware/esp32/main/controller_ui.h
+++ b/firmware/esp32/main/controller_ui.h
@@ -25,7 +25,6 @@ typedef struct {
   bool battery_low;
   bool heat_visible;
   bool heat_arc_visible;
-  bool steam_heat_eta_visible;
   bool ble_visible;
   bool ble_authenticated;
   uint32_t readable_mask;
@@ -34,7 +33,6 @@ typedef struct {
   uint16_t heat_progress_permille;
   const lv_img_dsc_t *custom_logo;
   char heat_eta_text[16];
-  char steam_heat_eta_text[16];
   char setup_status_text[LM_CTRL_UI_STATUS_TEXT_LEN];
   char setup_qr_payload[LM_CTRL_UI_SETUP_QR_LEN];
 } lm_ctrl_ui_view_t;

--- a/firmware/esp32/tests/host/src/test_cloud_api.c
+++ b/firmware/esp32/tests/host/src/test_cloud_api.c
@@ -191,6 +191,90 @@ static int test_parse_prebrew_widget_supports_both_widget_shapes(void) {
   return 0;
 }
 
+static int test_parse_dashboard_values_prefers_latest_ready_time_across_heating_boilers(void) {
+  static const char *response_body =
+    "{"
+      "\"widgets\":["
+        "{\"code\":\"CMCoffeeBoiler\",\"output\":{\"status\":\"HeatingUp\",\"readyStartTime\":1700000005000}},"
+        "{\"code\":\"CMSteamBoilerLevel\",\"output\":{\"status\":\"HeatingUp\",\"readyStartTime\":1700000015000}}"
+      "]"
+    "}";
+  cJSON *root = cJSON_Parse(response_body);
+  ctrl_values_t values = {0};
+  uint32_t loaded_mask = 0;
+  uint32_t feature_mask = 0;
+  lm_ctrl_machine_heat_info_t heat_info = {0};
+
+  ASSERT_TRUE(root != NULL);
+  ASSERT_EQ_INT(
+    ESP_OK,
+    lm_ctrl_cloud_parse_dashboard_root_values(
+      root,
+      &values,
+      &loaded_mask,
+      &feature_mask,
+      &heat_info,
+      NULL,
+      NULL
+    )
+  );
+  ASSERT_TRUE(heat_info.available);
+  ASSERT_TRUE(heat_info.heating);
+  ASSERT_TRUE(heat_info.eta_available);
+  ASSERT_TRUE(heat_info.coffee_heating);
+  ASSERT_TRUE(heat_info.steam_heating);
+  ASSERT_TRUE(heat_info.coffee_eta_available);
+  ASSERT_TRUE(heat_info.steam_eta_available);
+  ASSERT_EQ_I64(1700000015000LL, heat_info.ready_epoch_ms);
+  ASSERT_EQ_I64(1700000005000LL, heat_info.coffee_ready_epoch_ms);
+  ASSERT_EQ_I64(1700000015000LL, heat_info.steam_ready_epoch_ms);
+
+  cJSON_Delete(root);
+  return 0;
+}
+
+static int test_parse_dashboard_values_falls_back_to_coffee_eta_when_steam_is_not_heating(void) {
+  static const char *response_body =
+    "{"
+      "\"widgets\":["
+        "{\"code\":\"CMCoffeeBoiler\",\"output\":{\"status\":\"HeatingUp\",\"readyStartTime\":1700000005000}},"
+        "{\"code\":\"CMSteamBoilerLevel\",\"output\":{\"enabled\":false,\"status\":\"Ready\",\"readyStartTime\":1700000015000}}"
+      "]"
+    "}";
+  cJSON *root = cJSON_Parse(response_body);
+  ctrl_values_t values = {0};
+  uint32_t loaded_mask = 0;
+  uint32_t feature_mask = 0;
+  lm_ctrl_machine_heat_info_t heat_info = {0};
+
+  ASSERT_TRUE(root != NULL);
+  ASSERT_EQ_INT(
+    ESP_OK,
+    lm_ctrl_cloud_parse_dashboard_root_values(
+      root,
+      &values,
+      &loaded_mask,
+      &feature_mask,
+      &heat_info,
+      NULL,
+      NULL
+    )
+  );
+  ASSERT_TRUE(heat_info.available);
+  ASSERT_TRUE(heat_info.heating);
+  ASSERT_TRUE(heat_info.eta_available);
+  ASSERT_TRUE(heat_info.coffee_heating);
+  ASSERT_FALSE(heat_info.steam_heating);
+  ASSERT_TRUE(heat_info.coffee_eta_available);
+  ASSERT_FALSE(heat_info.steam_eta_available);
+  ASSERT_EQ_I64(1700000005000LL, heat_info.ready_epoch_ms);
+  ASSERT_EQ_I64(1700000005000LL, heat_info.coffee_ready_epoch_ms);
+  ASSERT_EQ_I64(0LL, heat_info.steam_ready_epoch_ms);
+
+  cJSON_Delete(root);
+  return 0;
+}
+
 int run_cloud_api_tests(void) {
   RUN_TEST(test_generate_installation_secret_matches_reference_vector);
   RUN_TEST(test_generate_installation_populates_uuid_secret_and_private_key);
@@ -199,5 +283,7 @@ int run_cloud_api_tests(void) {
   RUN_TEST(test_parse_dashboard_machine_status_extracts_online_signal);
   RUN_TEST(test_parse_dashboard_values_extracts_machine_and_bbw_state);
   RUN_TEST(test_parse_prebrew_widget_supports_both_widget_shapes);
+  RUN_TEST(test_parse_dashboard_values_prefers_latest_ready_time_across_heating_boilers);
+  RUN_TEST(test_parse_dashboard_values_falls_back_to_coffee_eta_when_steam_is_not_heating);
   return 0;
 }


### PR DESCRIPTION
## What changed
- collapse the controller warmup UI onto a single machine-level ETA path driven by the latest `ready_epoch_ms`
- remove the separate steam-specific warmup runtime/view state and reuse the generic warmup message on the steam screen
- add cloud parser tests that verify the overall ETA follows the slower heating boiler and falls back to the coffee boiler when steam is not heating

## Why
The steam boiler usually finishes later than the coffee boiler, so showing a separate steam warmup animation adds UI complexity without improving the operator-facing meaning of `Ready in X`. The controller should consistently communicate full machine readiness instead.

## Impact
The warmup ring and ETA text are now consistent across all main screens. When steam heating is active, the total ETA will usually reflect the steam boiler. If steam is off or not heating, the ETA falls back to the coffee boiler automatically.

## Validation
- `./tests/host/run.sh`
- `./dev.sh build`