### PR TITLE
[codex] improve cloud diagnostics and water alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,14 @@ The current ESP32 firmware supports:
   - steam boiler `Off / 1 / 2 / 3` level control from the controller screen
   - standby
 - cloud-backed prebrewing mode and timing changes
+- cloud-backed brew-by-weight mode and dose changes when the selected machine reports BBW support
 - on-device recovery actions for `Clear web password` and `Reset network`
 - periodic machine value refresh while the controller stays online
 - recipe presets for:
   - coffee boiler temperature
   - prebrewing on-time
   - prebrewing off-time
+  - brew-by-weight mode and dose targets when BBW is available
 
 The currently targeted hardware is a JC3636K718-style ESP32-S3 round controller board with:
 
@@ -99,6 +101,7 @@ If you want to flash the controller:
 - After home Wi-Fi is saved, the controller immediately tries to join that network. Once connected, the setup portal stays available again via the on-device setup gesture and the configured `http://<hostname>.local/` address.
 - The browser setup portal is currently split into `Overview`, `Controller`, `Network`, `Cloud`, `Recipes`, `Advanced`, and `Diagnostics`.
 - A crossed Wi-Fi icon means the controller has account/network context but the selected machine is not currently reachable through cloud. BLE control can still stay active in that state.
+- Brew by weight is currently a cloud-only path in the firmware: the UI and presets can expose it, but BBW writes still require cloud machine reachability.
 - The cloud login path expects a direct La Marzocco account email/password. Accounts created only through Apple or Google sign-in are not expected to work with the current controller login flow.
 - A possible workaround for Apple/Google-only accounts is to create a second La Marzocco account with a normal email/password login and grant that account access in the official app. Treat this as a best-effort workaround, not a guaranteed fix.
 - Main gestures are: swipe down for `Presets`, swipe up for `Setup`, and long-press on the setup screen to open `Recovery` for `Clear web password` or `Reset network`.

--- a/docs/controller/CLOUD_DASHBOARD_DEBUG.md
+++ b/docs/controller/CLOUD_DASHBOARD_DEBUG.md
@@ -106,6 +106,14 @@ For something like shot-timer hunting, the usual flow is:
 3. `snapshot --code ... --output ...`
 4. compare standby, heating, brewing, and post-shot snapshots
 
+Current firmware expectation for shot detection:
+
+- `status == "Brewing"` starts a shot
+- `brewingStartTime > 0` starts a shot
+- `mode == "BrewingMode"` by itself is not enough
+
+So when validating raw dashboard payloads, always compare those fields together instead of treating `BrewingMode` alone as a reliable live-shot signal.
+
 ## Output interpretation
 
 Each snapshot includes:

--- a/docs/controller/FIRMWARE_ARCHITECTURE.md
+++ b/docs/controller/FIRMWARE_ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Controller Firmware Architecture
 
-Last updated: 2026-04-18
+Last updated: 2026-04-20
 
 ## Goal
 
@@ -12,6 +12,8 @@ Keep the ESP32 firmware split by responsibility so Wi-Fi/setup, persisted settin
   minimal bootstrap, hardware bring-up, and top-level event-loop wiring
 - `firmware/esp32/main/controller_runtime.[ch]`
   runtime coordinator for controller state, sync cadence, deferred sends, and UI view-model construction
+- `firmware/esp32/main/controller_shot_timer.[ch]`
+  small runtime-owned shot-timer state machine for live/sticky/hidden transitions
 - `firmware/esp32/main/controller_ui.[ch]`
   render-only LVGL UI; no direct Wi-Fi or cloud reads
 - `firmware/esp32/main/machine_link_types.h`
@@ -78,6 +80,6 @@ There is no JavaScript-style `JSDoc` tooling here, but the purpose is the same.
 
 There is now a lightweight host-side test harness behind `firmware/esp32/dev.sh test`.
 
-- It targets seams that are worth checking without ESP-IDF hardware drivers: `controller_state`, cloud JSON parsing in `cloud_api`, and setup portal rendering in `setup_portal_page`.
+- It targets seams that are worth checking without ESP-IDF hardware drivers: `controller_state`, `controller_shot_timer`, cloud JSON parsing in `cloud_api`, and setup portal rendering in `setup_portal_page`.
 - It does not try to fake BLE, Wi-Fi driver state, LVGL runtime, or full HTTP/TLS integration.
 - The goal is fast regression coverage for the refactored pure/module boundaries, not a full firmware simulator.

--- a/docs/controller/SETUP_GUIDE.md
+++ b/docs/controller/SETUP_GUIDE.md
@@ -60,8 +60,8 @@ The current firmware provides a real local setup path:
    - `Overview` with portal reachability, current IP, and stable `.local` URL
    - `Controller` settings for hostname, language (`English` default), and optional local SVG header logo
    - `Network` with Wi-Fi storage and scan
-   - `Cloud` account storage, machine loading/selection, and setup-AP provisioning import
-   - `Recipes` for controller preset editing
+   - `Cloud` account storage, machine loading/selection, setup-AP provisioning import, and brew-by-weight editing when the selected machine reports BBW support
+   - `Recipes` for controller preset editing, including BBW fields when the selected machine reports BBW support
    - `Advanced` controller tuning and factory reset
    - `Diagnostics` for cloud heat debug and the optional remote screenshot route
 13. Swipe up on the main controller screen to reopen `Setup` later.
@@ -73,7 +73,7 @@ The current firmware provides a real local setup path:
 - A crossed Wi-Fi icon means the controller has network/account context but the selected machine is not currently reachable through cloud.
 - A solid Wi-Fi icon means the selected machine is reachable through cloud.
 - USB and battery indicators appear only when the controller reports USB power, charging, or low-battery state.
-- In the crossed-Wi-Fi state, local BLE control for temperature, steam, and status can stay available while cloud-only values such as prebrewing continue to wait for the remote path.
+- In the crossed-Wi-Fi state, local BLE control for temperature, steam, and status can stay available while cloud-only values such as prebrewing and brew by weight continue to wait for the remote path.
 
 ## Cloud account note
 
@@ -85,6 +85,7 @@ The current firmware provides a real local setup path:
 ## On-device gestures and reset behaviour
 
 - Swipe left/right on the main screen to move between the main settings pages.
+- If the selected machine reports brew-by-weight support, the main page cycle also includes BBW mode, Dose 1, and Dose 2 pages.
 - Swipe down on the main screen to open `Presets`.
 - Swipe up on the main screen to open `Setup`.
 - On the `Presets` screen, swipe up to return to the main screen.

--- a/docs/controller/SHOT_TIMER_WEBSOCKET_NOTES.md
+++ b/docs/controller/SHOT_TIMER_WEBSOCKET_NOTES.md
@@ -1,161 +1,128 @@
 # Shot Timer and Cloud WebSocket Notes
 
-Last updated: 2026-04-16
+Last updated: 2026-04-20
 
 ## Current status
 
-The controller-side shot timer has been removed again for now.
+The cloud websocket path is now implemented and working on the controller.
 
-Reason:
-- the old local shot timer path used by earlier `pylamarzocco` versions is no longer available on the current machine firmware
-- the currently known La Marzocco cloud websocket topics do not expose a usable live shot timer for this machine
+Current controller behaviour:
 
-The controller firmware should therefore currently be treated as:
-- no shot timer on-device
-- no active dependency on the unfinished cloud live-update path
+- authenticated STOMP websocket to `wss://lion.lamarzocco.io/ws/connect`
+- subscription to `/ws/sn/<serial>/dashboard`
+- automatic reconnect through the firmware worker when the websocket drops or Wi-Fi returns
+- on-device shot-timer screen driven from cloud dashboard updates
+- sticky final shot time after shot end, dismissed by any touch swipe
 
-## What was tested
+The shot timer itself is no longer "removed". It is implemented in firmware, but it still depends on whether the selected machine actually exposes usable shot fields through the cloud dashboard.
 
-### 1. Old local API path
+## Current shot-timer rules in firmware
 
-Older `pylamarzocco` releases used a local websocket on the machine itself:
+The controller starts a shot only when at least one of these is true in `CMMachineStatus`:
+
+- `status == "Brewing"`
+- `brewingStartTime > 0`
+
+It intentionally does not start a shot just because:
+
+- `mode == "BrewingMode"`
+
+That guard exists because the cloud dashboard can remain in `BrewingMode` even after a shot has ended.
+
+Once a live shot is active:
+
+- the timer counts up on a dedicated full-screen overlay
+- when the shot ends, the last visible time is frozen
+- the frozen time stays on-screen until the user dismisses it with any swipe gesture
+- if a new shot starts before dismissal, the sticky value is replaced immediately by the new live timer
+
+The current implementation does not yet use `lastCoffee.extractionSeconds` as a post-shot correction source.
+
+## What is confirmed
+
+### 1. Old local machine websocket path
+
+Older `pylamarzocco` versions used a local machine websocket such as:
 
 - `ws://<machine>:8081/api/v1/streaming`
 
-That path delivered events such as:
-- `BrewingStartedGroup1StopType`
-- `BrewingUpdateGroup1Time`
-- `BrewingStopped...`
-- `FlushStoppedGroup1Time`
+That path was the source of the historic shot-timer behaviour in older integrations.
 
-Those events drove:
-- `brew_active`
-- `brew_active_duration`
+On the currently tested machine/firmware, that old local path could not be recovered and should still be treated as gone.
 
-This was confirmed from:
-- `/private/tmp/pylm149/unpacked/pylamarzocco/devices/machine.py`
-- `/private/tmp/pylm149/unpacked/pylamarzocco/clients/local.py`
-- `/Users/kaspar/Documents/Projekte/pylamarzocco/docs/legacy/websockets.md`
+### 2. Cloud websocket transport
 
-### 2. Machine LAN reachability
+The controller-side cloud websocket is now confirmed working end-to-end:
 
-The machine was identified on the local network as:
-- `mi020904.fritz.box`
-- `192.168.178.50`
+- signed websocket upgrade headers
+- HTTP upgrade
+- STOMP `CONNECT`
+- STOMP `CONNECTED`
+- `SUBSCRIBE`
+- live `MESSAGE` frames from the dashboard destination
 
-Ports such as:
-- `80`
-- `443`
-- `8080`
-- `8081`
-- `8082`
-- `8083`
-- `8888`
+This is no longer an unfinished transport path.
 
-were tested and the old local API path did not respond.
+### 3. Current on-device implementation
 
-Conclusion:
-- the old local websocket route appears to be gone on the current firmware
+The controller firmware now contains:
 
-### 3. Current cloud websocket path
+- working websocket/STOMP live updates
+- shot state parsing from dashboard payloads
+- a dedicated shot-timer runtime state machine (`hidden`, `live`, `sticky`)
+- a dedicated shot-timer UI screen
 
-The current cloud STOMP websocket connection works:
+## Important limitation
 
-- endpoint: `wss://lion.lamarzocco.io/ws/connect`
+The tested machine used during controller development still did not expose usable live shot fields on the dashboard topic during a real shot.
 
-Authenticated STOMP subscriptions were tested locally on the Mac against the real machine.
+Observed during live websocket traffic on that machine:
 
-Confirmed working topics:
-- `/ws/sn/<serial>/dashboard`
-- `/ws/sn/<serial>/scheduling`
-
-Additional wildcard-style subscription attempts were also tested:
-- `/ws/sn/<serial>/*`
-- `/ws/sn/<serial>/**`
-- `/ws/sn/<serial>/*/*`
-- `/ws/sn/<serial>/**/**`
-- `/ws/sn/<serial>/#`
-- `/ws/sn/<serial>`
-
-These did not reveal any additional third topic. They only produced duplicates of `dashboard` and `scheduling`.
-
-## What the cloud websocket actually returned
-
-During real machine activity, including a shot, the websocket delivered live frames, but only snapshot-style payloads for:
-- `dashboard`
-- `scheduling`
-
-The relevant `dashboard` fields remained unusable for shot timing:
-
+- `status: "PoweredOn"`
+- `mode: "BrewingMode"`
 - `brewingStartTime: null`
 - `lastCoffee: null`
 - `lastFlush: null`
 
-Even during a real shot, no dedicated shot event or timer payload appeared on the known topics.
+In that situation the controller intentionally does not start the timer, because the payload is not trustworthy enough to infer a real shot.
 
-## Key conclusion
+## Micra / Linea Mini status
 
-The shot timer is currently not available through any of the known and testable paths:
+Current project status for Linea Micra and Linea Mini:
 
-1. The old local websocket path is gone.
-2. The known cloud websocket topics do not expose a usable shot timer for this machine.
-3. Broad subscription attempts did not reveal an additional public topic carrying shot state.
+- the shot-timer implementation is in place
+- the websocket transport is in place
+- the parser is aligned with the expected cloud fields
+- real-machine confirmation is still missing
 
-At this point, the shot timer should be considered unresolved, not partially implemented.
+Practical meaning:
 
-## Why earlier shot timer behaviour existed before
+- if a Micra or Linea Mini sends `status == "Brewing"` or a real `brewingStartTime`, the current firmware should show the shot timer as intended
+- this behaviour is implemented, but not yet confirmed on a real Micra/Linea Mini shot sequence
 
-The earlier shot timer behaviour came from the old local machine websocket path, not from the current cloud dashboard topic.
+So the correct statement is:
 
-That explains why:
-- older references still mention `brew_active_duration`
-- older integrations could expose a live shot timer
-- the current firmware and current cloud topic do not reproduce that behavior
-
-## Useful files and local test artifacts
-
-Local repo files:
-- `/Users/kaspar/Documents/Projekte/pylamarzocco/pylamarzocco/clients/_cloud.py`
-- `/Users/kaspar/Documents/Projekte/pylamarzocco/pylamarzocco/models/_schedule.py`
-- `/Users/kaspar/Documents/Projekte/pylamarzocco/docs/legacy/websockets.md`
-
-Temporary local test files created during debugging:
-- `/tmp/lm_ws_raw.py`
-- `/tmp/lm_ws_multi.py`
-- `/tmp/lm_poll_dashboard.py`
-- `/tmp/lm_poll_dashboard_slow.py`
-
-Temporary package inspection directories:
-- `/private/tmp/pylm149/unpacked`
-- `/private/tmp/pylm224/unpacked_now`
+- Micra/Linea Mini shot-timer support is implemented in firmware
+- it is not yet hardware-verified end-to-end
 
 ## Recommended next step
 
-Do not continue shot timer work on the ESP first.
+Validate the current implementation on a real Micra or Linea Mini that is known to produce dashboard updates during a shot.
 
-Instead, reverse engineer the official mobile app traffic:
+For that validation, capture raw `dashboard` payloads across:
 
-### Preferred order
+1. idle
+2. shot start
+3. mid-shot
+4. shot end
+5. a few seconds after shot end
 
-1. Try HTTPS/WSS MITM on the iPhone app
-   - `mitmproxy` or `Proxyman`
-   - same Wi-Fi as the Mac
-   - manual proxy on iPhone
-   - trusted root certificate on iPhone
-2. If the app uses certificate pinning:
-   - fall back to app analysis / decompilation
-   - or platform-specific pinning bypass work
-3. Only when a real shot-related destination or event is found:
-   - wire the controller shot timer back in
+Pay special attention to:
 
-## Suggested rule for future implementation
+- `status`
+- `mode`
+- `brewingStartTime`
+- `lastCoffee`
+- `lastFlush`
 
-Only re-enable the controller shot timer when at least one of these is true:
-- a stable live shot event source is identified
-- a stable cloud field with real-time shot start/stop becomes available
-- a new documented websocket destination is confirmed
-
-Until then, the cleaner behavior is:
-- no on-device shot timer
-- no fake timer
-- no partially working timer based on guesses
+If those machines still do not provide usable shot fields, the next investigation target is still the official app traffic. But that is now a data-source problem, not a missing controller websocket implementation.

--- a/firmware/esp32/README.md
+++ b/firmware/esp32/README.md
@@ -19,10 +19,14 @@ The current target is a JC3636K718-style round controller board with:
   - coffee boiler
   - prebrewing on-time
   - prebrewing off-time
+  - brew by weight mode and dose targets when the selected machine reports BBW support
   - steam boiler
   - standby
+  - shot timer
   - presets
   - setup
+- `controller_shot_timer.[ch]`
+  small runtime-owned shot-timer state machine with `hidden`, `live`, and `sticky` modes
 - `input.[ch]`
   vendor-style polling for the physical outer ring
 - `board_display.[ch]`
@@ -97,6 +101,8 @@ The current target is a JC3636K718-style round controller board with:
 - Swipe left/right: next or previous main settings page
 - Swipe down: open presets
 - Swipe up: open Wi-Fi/cloud setup
+- Shot-timer screen while a shot is running: swipes stay blocked
+- Sticky shot-timer screen after a shot: any swipe dismisses the frozen final time
 - Presets screen: swipe up to return
 - Setup screen: swipe down to return
 - Setup screen: long-press to open the on-device network reset flow
@@ -113,6 +119,7 @@ They currently store and load:
 - coffee boiler temperature
 - prebrewing on-time
 - prebrewing off-time
+- brew-by-weight mode, dose 1, and dose 2 when the selected machine reports BBW support
 
 They do not store or restore:
 
@@ -139,6 +146,7 @@ The browser portal currently supports:
 - keeping the default text header or storing a user-provided custom logo as a controller setting
 - loading machines from the cloud account
 - selecting the active machine and storing the serial/BLE binding needed by the controller
+- editing brew-by-weight mode and dose targets when the selected machine reports BBW support through the cloud dashboard
 
 The cloud login path expects a direct La Marzocco account email/password. Accounts created only through Apple or Google sign-in are not expected to work with the current controller onboarding flow. A possible workaround is to create a second La Marzocco account with a normal email/password login and share machine access to that account in the official app.
 
@@ -147,9 +155,24 @@ The firmware does not ship an official vendor logo asset. By default, the displa
 ## Runtime sync behaviour
 
 - BLE is preferred whenever the controller has an authenticated local machine link.
-- Cloud is used for prebrewing writes and as a dashboard-value fallback.
+- Cloud websocket live updates run when Wi-Fi, cloud credentials, and a machine selection are available.
+- Cloud is used for prebrewing writes, websocket live updates, and as a dashboard-value fallback.
+- Brew by weight is currently cloud-only in this firmware: BBW values are read from the cloud dashboard and BBW writes go through cloud machine commands, not the local BLE transport.
 - The controller refreshes machine-facing values periodically while it stays online.
 - If a value has not been loaded yet, the UI shows placeholders instead of stale defaults.
+- The shot timer is driven only from cloud dashboard signals `status == Brewing` or `brewingStartTime > 0`.
+- `mode == BrewingMode` alone intentionally does not start the shot timer.
+
+## Brew By Weight status
+
+Current BBW implementation status:
+
+- The firmware parses BBW support, mode, and dose targets from the cloud dashboard widget `CMBrewByWeightDoses`.
+- The round controller UI exposes BBW mode, Dose 1, and Dose 2 pages only when the selected machine reports BBW support.
+- Controller presets store and restore BBW mode and doses when BBW is available for the selected machine.
+- The setup portal also exposes a dedicated BBW form when the selected machine reports BBW support.
+- BBW writes currently go through cloud machine commands, not the local BLE path.
+- In practice that means BBW is implemented, but it still depends on cloud reachability and on the selected machine exposing BBW through the dashboard.
 
 ## Internal architecture
 
@@ -159,6 +182,8 @@ The firmware is now split by responsibility instead of putting setup, persistenc
   bootstrap and top-level wiring only
 - `controller_runtime.[ch]`
   event loop coordination, sync cadence, and UI view-model assembly
+- `controller_shot_timer.[ch]`
+  shot-timer runtime state machine used by `controller_runtime`
 - `controller_ui.[ch]`
   LVGL rendering only, driven by `ctrl_state_t` plus `lm_ctrl_ui_view_t`
 - `machine_link_types.h`
@@ -202,6 +227,8 @@ Additional module notes:
 
 - The firmware currently targets a specific JC3636K718-style board family.
 - Some machine capabilities still depend on La Marzocco cloud/backend behaviour.
+- Brew by weight is only shown when the cloud dashboard exposes BBW support for the selected machine, and BBW changes require a live cloud path.
+- The shot timer only appears when the cloud dashboard exposes usable brewing fields. It is implemented for Micra/Linea Mini-style dashboard signals, but not yet confirmed on a real Micra or Linea Mini.
 - The setup flow and UI are optimized for this project, not for generic reuse across controller hardware.
 
 ## Build & flash quickstart
@@ -234,7 +261,7 @@ ESPPORT=/dev/cu.usbmodemXXXX ./dev.sh quick
 
 The `quick` command uses `idf.py app-flash monitor`, so only the app partition is reflashed after the initial full flash.
 
-`./dev.sh test` runs the host-side unit-test harness for the pure controller state machine, cloud JSON parsing, and setup portal HTML rendering seams. It does not exercise BLE, Wi-Fi drivers, or on-device ESP-IDF runtime tasks.
+`./dev.sh test` runs the host-side unit-test harness for the pure controller state machine, shot-timer state machine, cloud JSON parsing, and setup portal HTML rendering seams. It does not exercise BLE, Wi-Fi drivers, or on-device ESP-IDF runtime tasks.
 
 ### Windows
 

--- a/firmware/esp32/main/app_main.c
+++ b/firmware/esp32/main/app_main.c
@@ -96,9 +96,10 @@ static esp_err_t machine_link_fetch_dashboard_values(
   ctrl_values_t *values,
   uint32_t *loaded_mask,
   uint32_t *feature_mask,
-  lm_ctrl_machine_heat_info_t *heat_info
+  lm_ctrl_machine_heat_info_t *heat_info,
+  lm_ctrl_machine_water_status_t *water_status
 ) {
-  return lm_ctrl_wifi_fetch_dashboard_values(values, loaded_mask, feature_mask, heat_info);
+  return lm_ctrl_wifi_fetch_dashboard_values(values, loaded_mask, feature_mask, heat_info, water_status);
 }
 
 void app_main(void) {

--- a/firmware/esp32/main/cloud_api.c
+++ b/firmware/esp32/main/cloud_api.c
@@ -750,6 +750,57 @@ bool lm_ctrl_cloud_parse_dashboard_machine_status(
   return parse_machine_status_fields(root, status);
 }
 
+bool lm_ctrl_cloud_parse_dashboard_water_status(
+  cJSON *root,
+  lm_ctrl_machine_water_status_t *status
+) {
+  cJSON *widgets;
+  cJSON *widget;
+
+  if (status == NULL) {
+    return false;
+  }
+
+  *status = (lm_ctrl_machine_water_status_t){0};
+  if (root == NULL) {
+    return false;
+  }
+
+  widgets = cJSON_GetObjectItemCaseSensitive(root, "widgets");
+  if (!cJSON_IsArray(widgets)) {
+    return false;
+  }
+
+  cJSON_ArrayForEach(widget, widgets) {
+    cJSON *code_item;
+    cJSON *output;
+    cJSON *alarm_item;
+
+    code_item = cJSON_GetObjectItemCaseSensitive(widget, "code");
+    output = cJSON_GetObjectItemCaseSensitive(widget, "output");
+    if (!cJSON_IsString(code_item) ||
+        code_item->valuestring == NULL ||
+        strcmp(code_item->valuestring, "CMNoWater") != 0 ||
+        !cJSON_IsObject(output)) {
+      continue;
+    }
+
+    alarm_item = cJSON_GetObjectItemCaseSensitive(output, "allarm");
+    if (!cJSON_IsBool(alarm_item)) {
+      alarm_item = cJSON_GetObjectItemCaseSensitive(output, "alarm");
+    }
+    if (!cJSON_IsBool(alarm_item)) {
+      continue;
+    }
+
+    status->available = true;
+    status->no_water = cJSON_IsTrue(alarm_item);
+    return true;
+  }
+
+  return false;
+}
+
 static bool parse_prebrew_widget_values(cJSON *widget, float *seconds_in, float *seconds_out) {
   cJSON *code_item;
   cJSON *output;

--- a/firmware/esp32/main/cloud_api.h
+++ b/firmware/esp32/main/cloud_api.h
@@ -115,6 +115,11 @@ bool lm_ctrl_cloud_parse_dashboard_machine_status(
   cJSON *root,
   lm_ctrl_cloud_machine_status_t *status
 );
+/** Extract the dashboard no-water alarm state when present. */
+bool lm_ctrl_cloud_parse_dashboard_water_status(
+  cJSON *root,
+  lm_ctrl_machine_water_status_t *status
+);
 
 /** Extract controller-facing values and feature flags from a dashboard JSON root object. */
 esp_err_t lm_ctrl_cloud_parse_dashboard_root_values(

--- a/firmware/esp32/main/cloud_dashboard.c
+++ b/firmware/esp32/main/cloud_dashboard.c
@@ -329,12 +329,14 @@ esp_err_t lm_ctrl_cloud_session_fetch_dashboard_values(
   ctrl_values_t *values,
   uint32_t *loaded_mask,
   uint32_t *feature_mask,
-  lm_ctrl_machine_heat_info_t *heat_info
+  lm_ctrl_machine_heat_info_t *heat_info,
+  lm_ctrl_machine_water_status_t *water_status
 ) {
   char error_text[160];
   cJSON *root = NULL;
   int64_t server_epoch_ms = 0;
   esp_err_t ret;
+  bool water_status_available = false;
 
   if (values == NULL || loaded_mask == NULL || feature_mask == NULL) {
     return ESP_ERR_INVALID_ARG;
@@ -350,8 +352,11 @@ esp_err_t lm_ctrl_cloud_session_fetch_dashboard_values(
   if (ret == ESP_OK && heat_info != NULL) {
     heat_info->observed_epoch_ms = server_epoch_ms;
   }
+  if (water_status != NULL) {
+    water_status_available = lm_ctrl_cloud_parse_dashboard_water_status(root, water_status);
+  }
   cJSON_Delete(root);
-  return ret;
+  return (ret == ESP_OK || water_status_available) ? ESP_OK : ret;
 }
 
 esp_err_t lm_ctrl_cloud_session_fetch_heat_debug_json(

--- a/firmware/esp32/main/cloud_live_updates.c
+++ b/firmware/esp32/main/cloud_live_updates.c
@@ -302,11 +302,13 @@ static void handle_cloud_dashboard_message(const char *message) {
   uint32_t loaded_mask = 0;
   uint32_t feature_mask = 0;
   lm_ctrl_machine_heat_info_t heat_info = {0};
+  lm_ctrl_machine_water_status_t water_status = {0};
   lm_ctrl_cloud_machine_status_t machine_status = {0};
   bool brew_active = false;
   int64_t brew_start_epoch_ms = 0;
   lm_ctrl_cloud_command_update_t updates[LM_CTRL_CLOUD_COMMAND_UPDATE_MAX] = {0};
   size_t update_count = 0;
+  bool parsed_values = false;
 
   if (message == NULL || message[0] == '\0') {
     return;
@@ -325,17 +327,31 @@ static void handle_cloud_dashboard_message(const char *message) {
     merge_cloud_machine_status(&machine_status);
   }
 
-  if (lm_ctrl_cloud_parse_dashboard_root_values(
-        root,
-        &values,
-        &loaded_mask,
-        &feature_mask,
-        &heat_info,
-        &brew_active,
-        &brew_start_epoch_ms
-      ) == ESP_OK) {
-    lm_ctrl_machine_link_apply_cloud_dashboard_values(&values, loaded_mask, feature_mask, &heat_info);
+  parsed_values = lm_ctrl_cloud_parse_dashboard_root_values(
+      root,
+      &values,
+      &loaded_mask,
+      &feature_mask,
+      &heat_info,
+      &brew_active,
+      &brew_start_epoch_ms
+    ) == ESP_OK;
+  (void)lm_ctrl_cloud_parse_dashboard_water_status(root, &water_status);
+
+  if (parsed_values) {
+    if (heat_info.available && heat_info.observed_epoch_ms == 0) {
+      heat_info.observed_epoch_ms = current_epoch_ms();
+    }
+    lm_ctrl_machine_link_apply_cloud_dashboard_values(
+      &values,
+      loaded_mask,
+      feature_mask,
+      &heat_info,
+      water_status.available ? &water_status : NULL
+    );
     set_brew_timer_state(brew_active, brew_start_epoch_ms);
+  } else if (water_status.available) {
+    lm_ctrl_machine_link_apply_cloud_dashboard_values(&values, 0, 0, NULL, &water_status);
   }
   if (update_count != 0) {
     lm_ctrl_machine_link_apply_cloud_command_updates(updates, update_count);

--- a/firmware/esp32/main/cloud_session.h
+++ b/firmware/esp32/main/cloud_session.h
@@ -36,7 +36,8 @@ esp_err_t lm_ctrl_cloud_session_fetch_dashboard_values(
   ctrl_values_t *values,
   uint32_t *loaded_mask,
   uint32_t *feature_mask,
-  lm_ctrl_machine_heat_info_t *heat_info
+  lm_ctrl_machine_heat_info_t *heat_info,
+  lm_ctrl_machine_water_status_t *water_status
 );
 /** Fetch only the prebrewing timing values from the cloud dashboard. */
 esp_err_t lm_ctrl_cloud_session_fetch_prebrewing_values(float *seconds_in, float *seconds_out);

--- a/firmware/esp32/main/controller_runtime.c
+++ b/firmware/esp32/main/controller_runtime.c
@@ -82,6 +82,9 @@ static int64_t current_epoch_ms(void) {
   if (gettimeofday(&tv, NULL) != 0) {
     return 0;
   }
+  if (tv.tv_sec < 1700000000) {
+    return 0;
+  }
 
   return ((int64_t)tv.tv_sec * 1000LL) + (tv.tv_usec / 1000LL);
 }
@@ -204,6 +207,8 @@ static void sync_heat_state(lm_ctrl_runtime_t *runtime) {
   }
   if (have_machine_eta) {
     clear_heat_refresh(&runtime->heat_refresh);
+  } else if (runtime->heat_refresh.until_us == 0) {
+    arm_heat_refresh(&runtime->heat_refresh, 0);
   }
 }
 
@@ -1091,6 +1096,7 @@ void lm_ctrl_runtime_build_ui_view(const lm_ctrl_runtime_t *runtime, lm_ctrl_ui_
     wifi_info.heat_display_enabled &&
     runtime->heat_state.duration_us > 0 &&
     view->heat_visible;
+  view->water_alert_visible = machine_info.water_status.available && machine_info.water_status.no_water;
   view->ble_visible = machine_info.connected || machine_info.authenticated;
   view->ble_authenticated = machine_info.authenticated;
   view->readable_mask = access.readable_mask;

--- a/firmware/esp32/main/controller_ui.c
+++ b/firmware/esp32/main/controller_ui.c
@@ -22,6 +22,7 @@ static const lv_color_t COLOR_RING = LV_COLOR_MAKE(0x92, 0x63, 0x33);
 static const lv_color_t COLOR_TEXT = LV_COLOR_MAKE(0xF4, 0xEF, 0xE7);
 static const lv_color_t COLOR_MUTED = LV_COLOR_MAKE(0xB7, 0xA0, 0x8B);
 static const lv_color_t COLOR_ACTIVE = LV_COLOR_MAKE(0xFF, 0xC6, 0x85);
+static const lv_color_t COLOR_WATER = LV_COLOR_MAKE(0x73, 0xC8, 0xFF);
 static const lv_color_t COLOR_BUTTON = LV_COLOR_MAKE(0x3A, 0x2A, 0x21);
 static const char *BATTERY_CHARGING_SYMBOL = LV_SYMBOL_BATTERY_FULL LV_SYMBOL_CHARGE;
 static const char *ICON_SLASH_SYMBOL = "/";
@@ -331,6 +332,21 @@ static void format_main_unavailable_placeholder(
       );
       break;
   }
+}
+
+static void format_no_water_hint(ctrl_language_t language, char *hint, size_t hint_size) {
+  if (hint == NULL || hint_size == 0) {
+    return;
+  }
+
+  snprintf(
+    hint,
+    hint_size,
+    "%s",
+    language == CTRL_LANGUAGE_DE
+      ? "Kein Wasser erkannt.\nTank prüfen und füllen."
+      : "No water detected.\nCheck and refill tank."
+  );
 }
 
 static void format_main_value(
@@ -705,6 +721,9 @@ static void render_main_screen(
   } else {
     format_main_unavailable_placeholder(state->focus, language, value, sizeof(value), hint, sizeof(hint));
   }
+  if (view != NULL && view->water_alert_visible) {
+    format_no_water_hint(language, hint, sizeof(hint));
+  }
   if (view != NULL && view->heat_arc_visible) {
     lv_arc_set_value(ui->heat_arc, view->heat_progress_permille);
   }
@@ -764,7 +783,7 @@ static void render_connection_icons(lm_ctrl_ui_t *ui, const lm_ctrl_ui_view_t *v
     const char *symbol;
     lv_color_t color;
   } icon_slot_t;
-  icon_slot_t slots[5];
+  icon_slot_t slots[6];
   lm_ctrl_indicator_state_t wifi_indicator = LM_CTRL_INDICATOR_HIDDEN;
   bool wifi_crossed = false;
   size_t visible_count = 0;
@@ -782,6 +801,7 @@ static void render_connection_icons(lm_ctrl_ui_t *ui, const lm_ctrl_ui_view_t *v
   set_hidden(ui->usb_icon, true);
   set_hidden(ui->battery_icon, true);
   set_hidden(ui->heat_icon, true);
+  set_hidden(ui->water_icon, true);
   set_hidden(ui->ble_icon, true);
 
   switch (wifi_indicator) {
@@ -810,6 +830,14 @@ static void render_connection_icons(lm_ctrl_ui_t *ui, const lm_ctrl_ui_view_t *v
       .obj = ui->heat_icon,
       .symbol = LV_SYMBOL_CHARGE,
       .color = COLOR_ACTIVE,
+    };
+  }
+
+  if (view->water_alert_visible) {
+    slots[visible_count++] = (icon_slot_t){
+      .obj = ui->water_icon,
+      .symbol = LV_SYMBOL_TINT,
+      .color = COLOR_WATER,
     };
   }
 
@@ -1077,6 +1105,11 @@ esp_err_t lm_ctrl_ui_init(
   lv_obj_align(ui->heat_icon, LV_ALIGN_TOP_MID, -34, 48);
   set_hidden(ui->heat_icon, true);
 
+  ui->water_icon = lv_label_create(ui->screen);
+  lv_obj_set_style_text_font(ui->water_icon, UI_FONT_14, 0);
+  lv_obj_align(ui->water_icon, LV_ALIGN_TOP_MID, 0, 48);
+  set_hidden(ui->water_icon, true);
+
   ui->ble_icon = lv_label_create(ui->screen);
   lv_obj_set_style_text_font(ui->ble_icon, UI_FONT_14, 0);
   lv_obj_align(ui->ble_icon, LV_ALIGN_TOP_MID, 0, 48);
@@ -1269,6 +1302,7 @@ esp_err_t lm_ctrl_ui_init(
   lv_obj_move_foreground(ui->usb_icon);
   lv_obj_move_foreground(ui->battery_icon);
   lv_obj_move_foreground(ui->heat_icon);
+  lv_obj_move_foreground(ui->water_icon);
   lv_obj_move_foreground(ui->ble_icon);
   lv_obj_move_foreground(ui->page_label);
 

--- a/firmware/esp32/main/controller_ui.h
+++ b/firmware/esp32/main/controller_ui.h
@@ -25,6 +25,7 @@ typedef struct {
   bool battery_low;
   bool heat_visible;
   bool heat_arc_visible;
+  bool water_alert_visible;
   bool ble_visible;
   bool ble_authenticated;
   bool shot_timer_visible;
@@ -78,6 +79,7 @@ struct lm_ctrl_ui_s {
   lv_obj_t *usb_icon;
   lv_obj_t *battery_icon;
   lv_obj_t *heat_icon;
+  lv_obj_t *water_icon;
   lv_obj_t *ble_icon;
   lv_obj_t *heat_arc;
   lv_obj_t *page_label;

--- a/firmware/esp32/main/machine_link.c
+++ b/firmware/esp32/main/machine_link.c
@@ -33,6 +33,23 @@ static bool heat_info_equal(const lm_ctrl_machine_heat_info_t *lhs, const lm_ctr
          lhs->steam_ready_epoch_ms == rhs->steam_ready_epoch_ms;
 }
 
+static bool water_status_equal(const lm_ctrl_machine_water_status_t *lhs, const lm_ctrl_machine_water_status_t *rhs) {
+  if (lhs == NULL || rhs == NULL) {
+    return lhs == rhs;
+  }
+
+  return lhs->available == rhs->available &&
+         lhs->no_water == rhs->no_water;
+}
+
+static lm_ctrl_machine_water_status_t preferred_water_status_locked(void) {
+  if (s_link.ble_water_status.available) {
+    return s_link.ble_water_status;
+  }
+
+  return s_link.cloud_water_status;
+}
+
 static ctrl_steam_level_t preferred_non_off_steam_level_locked(void) {
   if (ctrl_steam_level_enabled(s_link.reported_values.steam_level)) {
     return ctrl_steam_level_normalize(s_link.reported_values.steam_level);
@@ -71,6 +88,9 @@ void set_statusf(const char *fmt, ...) {
 }
 
 void clear_connection_state_locked(void) {
+  const lm_ctrl_machine_water_status_t previous_water_status = preferred_water_status_locked();
+  lm_ctrl_machine_water_status_t current_water_status;
+
   s_link.scanning = false;
   s_link.connect_after_scan = false;
   s_link.connect_in_progress = false;
@@ -88,6 +108,12 @@ void clear_connection_state_locked(void) {
   s_link.mtu_ready = false;
   s_link.discovered_def_handle = 0;
   s_link.discovered_properties = 0;
+  s_link.ble_water_status = (lm_ctrl_machine_water_status_t){0};
+
+  current_water_status = preferred_water_status_locked();
+  if (!water_status_equal(&previous_water_status, &current_water_status)) {
+    s_link.status_version++;
+  }
 }
 
 void snapshot_desired_values(ctrl_values_t *values) {
@@ -556,6 +582,42 @@ void update_heat_info(const lm_ctrl_machine_heat_info_t *info) {
   portEXIT_CRITICAL(&s_link_lock);
 }
 
+void update_cloud_water_status(const lm_ctrl_machine_water_status_t *status) {
+  lm_ctrl_machine_water_status_t previous_water_status;
+  lm_ctrl_machine_water_status_t current_water_status;
+
+  if (status == NULL) {
+    return;
+  }
+
+  portENTER_CRITICAL(&s_link_lock);
+  previous_water_status = preferred_water_status_locked();
+  s_link.cloud_water_status = *status;
+  current_water_status = preferred_water_status_locked();
+  if (!water_status_equal(&previous_water_status, &current_water_status)) {
+    s_link.status_version++;
+  }
+  portEXIT_CRITICAL(&s_link_lock);
+}
+
+void update_ble_water_status(const lm_ctrl_machine_water_status_t *status) {
+  lm_ctrl_machine_water_status_t previous_water_status;
+  lm_ctrl_machine_water_status_t current_water_status;
+
+  if (status == NULL) {
+    return;
+  }
+
+  portENTER_CRITICAL(&s_link_lock);
+  previous_water_status = preferred_water_status_locked();
+  s_link.ble_water_status = *status;
+  current_water_status = preferred_water_status_locked();
+  if (!water_status_equal(&previous_water_status, &current_water_status)) {
+    s_link.status_version++;
+  }
+  portEXIT_CRITICAL(&s_link_lock);
+}
+
 bool should_skip_ble_attempt(void) {
   int64_t last_failure_us;
 
@@ -638,6 +700,8 @@ static void machine_link_worker(void *arg) {
         ctrl_values_t cloud_values = {0};
         ctrl_values_t ble_values = {0};
         lm_ctrl_machine_heat_info_t heat_info = {0};
+        lm_ctrl_machine_water_status_t cloud_water_status = {0};
+        lm_ctrl_machine_water_status_t ble_water_status = {0};
         uint32_t merged_mask = 0;
         uint32_t cloud_loaded_mask = 0;
         uint32_t ble_loaded_mask = 0;
@@ -645,10 +709,22 @@ static void machine_link_worker(void *arg) {
         bool synced = false;
 
         if ((sync_request_flags & LM_CTRL_MACHINE_SYNC_CLOUD) != 0) {
-          synced |= fetch_values_via_cloud(&cloud_values, &cloud_loaded_mask, &feature_mask, &heat_info);
-          update_feature_mask(feature_mask);
+          synced |= fetch_values_via_cloud(
+            &cloud_values,
+            &cloud_loaded_mask,
+            &feature_mask,
+            &heat_info,
+            &cloud_water_status
+          );
+          if (cloud_loaded_mask != 0 || feature_mask != 0) {
+            update_feature_mask(feature_mask);
+          }
           if (heat_info.available) {
             update_heat_info(&heat_info);
+          }
+          if (cloud_water_status.available) {
+            update_cloud_water_status(&cloud_water_status);
+            synced = true;
           }
           if (cloud_loaded_mask != 0) {
             merged_values = cloud_values;
@@ -658,7 +734,7 @@ static void machine_link_worker(void *arg) {
         }
 
         if ((sync_request_flags & LM_CTRL_MACHINE_SYNC_BLE) != 0 &&
-            fetch_values_via_ble(&binding, &ble_values, &ble_loaded_mask)) {
+            fetch_values_via_ble(&binding, &ble_values, &ble_loaded_mask, &ble_water_status)) {
           if ((ble_loaded_mask & LM_CTRL_MACHINE_FIELD_STANDBY) != 0) {
             merged_values.standby_on = ble_values.standby_on;
           }
@@ -669,6 +745,9 @@ static void machine_link_worker(void *arg) {
             merged_values.steam_level = ble_values.steam_level;
           }
           merged_mask |= ble_loaded_mask;
+          if (ble_water_status.available) {
+            update_ble_water_status(&ble_water_status);
+          }
           synced = true;
         }
 
@@ -1015,6 +1094,7 @@ void lm_ctrl_machine_link_get_info(lm_ctrl_machine_link_info_t *info) {
   info->sync_flags = s_link.sync_request_flags;
   info->loaded_mask = s_link.loaded_mask;
   info->feature_mask = s_link.feature_mask;
+  info->water_status = preferred_water_status_locked();
   portEXIT_CRITICAL(&s_link_lock);
 }
 

--- a/firmware/esp32/main/machine_link.h
+++ b/firmware/esp32/main/machine_link.h
@@ -27,7 +27,8 @@ typedef struct {
     ctrl_values_t *values,
     uint32_t *loaded_mask,
     uint32_t *feature_mask,
-    lm_ctrl_machine_heat_info_t *heat_info
+    lm_ctrl_machine_heat_info_t *heat_info,
+    lm_ctrl_machine_water_status_t *water_status
   );
 } lm_ctrl_machine_link_deps_t;
 
@@ -48,7 +49,8 @@ void lm_ctrl_machine_link_apply_cloud_dashboard_values(
   const ctrl_values_t *values,
   uint32_t loaded_mask,
   uint32_t feature_mask,
-  const lm_ctrl_machine_heat_info_t *heat_info
+  const lm_ctrl_machine_heat_info_t *heat_info,
+  const lm_ctrl_machine_water_status_t *water_status
 );
 /** Apply command updates delivered asynchronously by the cloud websocket. */
 void lm_ctrl_machine_link_apply_cloud_command_updates(const lm_ctrl_cloud_command_update_t *updates, size_t update_count);

--- a/firmware/esp32/main/machine_link_ble.c
+++ b/firmware/esp32/main/machine_link_ble.c
@@ -975,6 +975,30 @@ static esp_err_t read_machine_mode_via_ble(bool *out_standby_on) {
   return ret;
 }
 
+static esp_err_t read_tank_status_via_ble(bool *out_tank_ok) {
+  char response[LM_CTRL_MACHINE_RESPONSE_MAX];
+  cJSON *root = NULL;
+  esp_err_t ret = ESP_FAIL;
+
+  if (out_tank_ok == NULL) {
+    return ESP_ERR_INVALID_ARG;
+  }
+
+  ESP_RETURN_ON_ERROR(
+    request_machine_read_value(LM_CTRL_MACHINE_READ_TANK_STATUS, response, sizeof(response)),
+    TAG,
+    "tankStatus read failed"
+  );
+
+  root = cJSON_Parse(response);
+  if (cJSON_IsBool(root)) {
+    *out_tank_ok = cJSON_IsTrue(root);
+    ret = ESP_OK;
+  }
+  cJSON_Delete(root);
+  return ret;
+}
+
 static esp_err_t read_boilers_via_ble(
   float *out_temperature_c,
   ctrl_steam_level_t *out_steam_level,
@@ -1028,7 +1052,8 @@ static esp_err_t read_boilers_via_ble(
 bool fetch_values_via_ble(
   const lm_ctrl_machine_binding_t *binding,
   ctrl_values_t *values,
-  uint32_t *loaded_mask
+  uint32_t *loaded_mask,
+  lm_ctrl_machine_water_status_t *water_status
 ) {
   uint32_t local_loaded_mask = 0;
 
@@ -1039,6 +1064,9 @@ bool fetch_values_via_ble(
   *values = (ctrl_values_t){0};
   values->steam_level = snapshot_preferred_steam_level();
   *loaded_mask = 0;
+  if (water_status != NULL) {
+    *water_status = (lm_ctrl_machine_water_status_t){0};
+  }
 
   if (!machine_link_ble_transport_enabled()) {
     return false;
@@ -1060,8 +1088,16 @@ bool fetch_values_via_ble(
   if (read_boilers_via_ble(&values->temperature_c, &values->steam_level, values->steam_level) == ESP_OK) {
     local_loaded_mask |= LM_CTRL_MACHINE_FIELD_TEMPERATURE | LM_CTRL_MACHINE_FIELD_STEAM;
   }
+  if (water_status != NULL) {
+    bool tank_ok = false;
 
-  if (local_loaded_mask != 0) {
+    if (read_tank_status_via_ble(&tank_ok) == ESP_OK) {
+      water_status->available = true;
+      water_status->no_water = !tank_ok;
+    }
+  }
+
+  if (local_loaded_mask != 0 || (water_status != NULL && water_status->available)) {
     *loaded_mask = local_loaded_mask;
     clear_ble_failure();
     return true;

--- a/firmware/esp32/main/machine_link_cloud.c
+++ b/firmware/esp32/main/machine_link_cloud.c
@@ -17,7 +17,8 @@ bool fetch_values_via_cloud(
   ctrl_values_t *values,
   uint32_t *loaded_mask,
   uint32_t *feature_mask,
-  lm_ctrl_machine_heat_info_t *heat_info
+  lm_ctrl_machine_heat_info_t *heat_info,
+  lm_ctrl_machine_water_status_t *water_status
 ) {
   if (values == NULL || loaded_mask == NULL || feature_mask == NULL) {
     return false;
@@ -34,13 +35,19 @@ bool fetch_values_via_cloud(
   if (heat_info != NULL) {
     *heat_info = (lm_ctrl_machine_heat_info_t){0};
   }
+  if (water_status != NULL) {
+    *water_status = (lm_ctrl_machine_water_status_t){0};
+  }
 
   if (s_deps.fetch_dashboard_values == NULL ||
-      s_deps.fetch_dashboard_values(values, loaded_mask, feature_mask, heat_info) != ESP_OK) {
+      s_deps.fetch_dashboard_values(values, loaded_mask, feature_mask, heat_info, water_status) != ESP_OK) {
     return false;
   }
 
-  return *loaded_mask != 0 || *feature_mask != 0 || (heat_info != NULL && heat_info->available);
+  return *loaded_mask != 0 ||
+         *feature_mask != 0 ||
+         (heat_info != NULL && heat_info->available) ||
+         (water_status != NULL && water_status->available);
 }
 
 
@@ -551,16 +558,22 @@ void lm_ctrl_machine_link_apply_cloud_dashboard_values(
   const ctrl_values_t *values,
   uint32_t loaded_mask,
   uint32_t feature_mask,
-  const lm_ctrl_machine_heat_info_t *heat_info
+  const lm_ctrl_machine_heat_info_t *heat_info,
+  const lm_ctrl_machine_water_status_t *water_status
 ) {
   if (!s_link.initialized) {
     return;
   }
 
-  update_feature_mask(feature_mask);
-  update_reported_values(values, loaded_mask);
+  if (loaded_mask != 0 || feature_mask != 0) {
+    update_feature_mask(feature_mask);
+    update_reported_values(values, loaded_mask);
+  }
   if (heat_info != NULL && heat_info->available) {
     update_heat_info(heat_info);
+  }
+  if (water_status != NULL && water_status->available) {
+    update_cloud_water_status(water_status);
   }
 }
 

--- a/firmware/esp32/main/machine_link_internal.h
+++ b/firmware/esp32/main/machine_link_internal.h
@@ -83,6 +83,8 @@ typedef struct {
   ctrl_values_t reported_values;
   ctrl_values_t remote_values;
   lm_ctrl_machine_heat_info_t heat_info;
+  lm_ctrl_machine_water_status_t cloud_water_status;
+  lm_ctrl_machine_water_status_t ble_water_status;
   uint32_t pending_mask;
   uint32_t inflight_cloud_mask;
   uint32_t loaded_mask;
@@ -197,14 +199,22 @@ void clear_ble_failure(void);
 void update_reported_values(const ctrl_values_t *values, uint32_t loaded_mask);
 void update_feature_mask(uint32_t feature_mask);
 void update_heat_info(const lm_ctrl_machine_heat_info_t *info);
+void update_cloud_water_status(const lm_ctrl_machine_water_status_t *status);
+void update_ble_water_status(const lm_ctrl_machine_water_status_t *status);
 bool should_skip_ble_attempt(void);
 
-bool fetch_values_via_ble(const lm_ctrl_machine_binding_t *binding, ctrl_values_t *values, uint32_t *loaded_mask);
+bool fetch_values_via_ble(
+  const lm_ctrl_machine_binding_t *binding,
+  ctrl_values_t *values,
+  uint32_t *loaded_mask,
+  lm_ctrl_machine_water_status_t *water_status
+);
 bool fetch_values_via_cloud(
   ctrl_values_t *values,
   uint32_t *loaded_mask,
   uint32_t *feature_mask,
-  lm_ctrl_machine_heat_info_t *heat_info
+  lm_ctrl_machine_heat_info_t *heat_info,
+  lm_ctrl_machine_water_status_t *water_status
 );
 esp_err_t ensure_connected_and_authenticated(const lm_ctrl_machine_binding_t *binding);
 const char *steam_level_cloud_code(ctrl_steam_level_t level);

--- a/firmware/esp32/main/machine_link_types.h
+++ b/firmware/esp32/main/machine_link_types.h
@@ -44,6 +44,12 @@ typedef struct {
   int64_t steam_ready_epoch_ms;
 } lm_ctrl_machine_heat_info_t;
 
+/** Water supply status surfaced by BLE or the cloud dashboard. */
+typedef struct {
+  bool available;
+  bool no_water;
+} lm_ctrl_machine_water_status_t;
+
 /** Sync sources that can be requested from the machine link worker. */
 typedef enum {
   LM_CTRL_MACHINE_SYNC_NONE = 0,
@@ -79,6 +85,7 @@ typedef struct {
   uint32_t sync_flags;
   uint32_t loaded_mask;
   uint32_t feature_mask;
+  lm_ctrl_machine_water_status_t water_status;
 } lm_ctrl_machine_link_info_t;
 
 #ifdef __cplusplus

--- a/firmware/esp32/main/setup_portal_page.h
+++ b/firmware/esp32/main/setup_portal_page.h
@@ -18,7 +18,7 @@ extern "C" {
 typedef struct {
   char status_html[512];
   char machine_status[160];
-  char debug_status_html[768];
+  char debug_status_html[1024];
   char banner_html[256];
   char csrf_token_html[96];
   char ssid_html[96];

--- a/firmware/esp32/main/setup_portal_presenter.c
+++ b/firmware/esp32/main/setup_portal_presenter.c
@@ -13,8 +13,8 @@ typedef struct {
   char status[256];
   char status_html[512];
   char machine_status[160];
-  char debug_status[512];
-  char debug_status_html[768];
+  char debug_status[640];
+  char debug_status_html[1024];
   char banner_html[256];
   char csrf_token_html[96];
   char ssid_html[96];
@@ -110,6 +110,12 @@ static void format_debug_summary(
     "Station: %s\n"
     "IP: %.15s\n"
     "Cloud account: %.47s\n"
+    "Cloud probe: %s\n"
+    "Cloud HTTP in flight: %u\n"
+    "Cloud WS active: %s\n"
+    "Cloud WS transport: %s\n"
+    "Cloud WS STOMP: %s\n"
+    "Cloud machine online: %s\n"
     "Cloud provisioning: %s\n"
     "Machine selected: %.31s\n"
     "Header logo: %s\n"
@@ -127,6 +133,12 @@ static void format_debug_summary(
     wifi_info->sta_connected ? "connected" : (wifi_info->sta_connecting ? "connecting" : "idle"),
     wifi_info->sta_ip[0] != '\0' ? wifi_info->sta_ip : "--",
     wifi_info->cloud_connected ? "connected" : (wifi_info->has_cloud_credentials ? "configured" : "not configured"),
+    wifi_info->cloud_probe_active ? "running" : "idle",
+    (unsigned)wifi_info->cloud_http_requests_in_flight,
+    wifi_info->cloud_live_updates_active ? "yes" : "no",
+    wifi_info->cloud_ws_transport_connected ? "yes" : "no",
+    wifi_info->cloud_ws_connected ? "yes" : "no",
+    !wifi_info->cloud_machine_status_known ? "unknown" : (wifi_info->machine_cloud_online ? "yes" : "no"),
     wifi_info->has_cloud_provisioning ? "ready" : "missing",
     wifi_info->has_machine_selection ? wifi_info->machine_serial : "no",
     wifi_info->has_custom_logo ? "custom" : "default text",

--- a/firmware/esp32/main/wifi_setup.c
+++ b/firmware/esp32/main/wifi_setup.c
@@ -891,6 +891,13 @@ void lm_ctrl_wifi_get_info(lm_ctrl_wifi_info_t *info) {
   info->language = s_state.language;
   info->has_cloud_credentials = s_state.has_cloud_credentials;
   info->cloud_connected = s_state.cloud_connected;
+  info->cloud_probe_active = s_state.cloud_probe_task != NULL;
+  info->cloud_live_updates_active =
+    s_state.cloud_ws_task != NULL ||
+    s_state.cloud_ws_transport_connected ||
+    s_state.cloud_ws_connected;
+  info->cloud_ws_transport_connected = s_state.cloud_ws_transport_connected;
+  info->cloud_ws_connected = s_state.cloud_ws_connected;
   info->cloud_machine_status = s_state.cloud_machine_status;
   info->cloud_machine_status_known = lm_ctrl_cloud_machine_status_is_known(&s_state.cloud_machine_status);
   info->machine_cloud_online = lm_ctrl_cloud_machine_status_is_online(&s_state.cloud_machine_status);
@@ -900,6 +907,7 @@ void lm_ctrl_wifi_get_info(lm_ctrl_wifi_info_t *info) {
   info->heat_display_enabled = s_state.heat_display_enabled;
   info->debug_screenshot_enabled = s_state.debug_screenshot_enabled;
   info->web_auth_mode = s_state.web_auth_mode;
+  info->cloud_http_requests_in_flight = s_state.cloud_http_requests_in_flight;
   copy_text(info->portal_ssid, sizeof(info->portal_ssid), s_state.portal_ssid);
   copy_text(info->portal_password, sizeof(info->portal_password), s_state.portal_password);
   copy_text(info->sta_ssid, sizeof(info->sta_ssid), s_state.sta_ssid);
@@ -1034,7 +1042,8 @@ esp_err_t lm_ctrl_wifi_fetch_dashboard_values(
   ctrl_values_t *values,
   uint32_t *loaded_mask,
   uint32_t *feature_mask,
-  lm_ctrl_machine_heat_info_t *heat_info
+  lm_ctrl_machine_heat_info_t *heat_info,
+  lm_ctrl_machine_water_status_t *water_status
 ) {
-  return lm_ctrl_cloud_session_fetch_dashboard_values(values, loaded_mask, feature_mask, heat_info);
+  return lm_ctrl_cloud_session_fetch_dashboard_values(values, loaded_mask, feature_mask, heat_info, water_status);
 }

--- a/firmware/esp32/main/wifi_setup.h
+++ b/firmware/esp32/main/wifi_setup.h
@@ -69,7 +69,8 @@ esp_err_t lm_ctrl_wifi_fetch_dashboard_values(
   ctrl_values_t *values,
   uint32_t *loaded_mask,
   uint32_t *feature_mask,
-  lm_ctrl_machine_heat_info_t *heat_info
+  lm_ctrl_machine_heat_info_t *heat_info,
+  lm_ctrl_machine_water_status_t *water_status
 );
 /** Read only the prebrewing timing values from the cloud dashboard. */
 esp_err_t lm_ctrl_wifi_fetch_prebrewing_values(float *seconds_in, float *seconds_out);

--- a/firmware/esp32/main/wifi_setup_types.h
+++ b/firmware/esp32/main/wifi_setup_types.h
@@ -31,6 +31,10 @@ typedef struct {
   bool has_credentials;
   bool has_cloud_credentials;
   bool cloud_connected;
+  bool cloud_probe_active;
+  bool cloud_live_updates_active;
+  bool cloud_ws_transport_connected;
+  bool cloud_ws_connected;
   bool cloud_machine_status_known;
   bool machine_cloud_online;
   bool has_machine_selection;
@@ -53,6 +57,7 @@ typedef struct {
   char machine_name[64];
   char machine_model[32];
   char machine_serial[32];
+  uint8_t cloud_http_requests_in_flight;
 } lm_ctrl_wifi_info_t;
 
 /** Live brew timer state derived from cloud dashboard websocket updates. */

--- a/firmware/esp32/tests/host/src/test_cloud_api.c
+++ b/firmware/esp32/tests/host/src/test_cloud_api.c
@@ -115,6 +115,19 @@ static int test_parse_dashboard_machine_status_extracts_online_signal(void) {
   return 0;
 }
 
+static int test_parse_dashboard_water_status_extracts_no_water_alarm(void) {
+  cJSON *root = cJSON_Parse("{\"widgets\":[{\"code\":\"CMNoWater\",\"output\":{\"allarm\":true}}]}");
+  lm_ctrl_machine_water_status_t water_status = {0};
+
+  ASSERT_TRUE(root != NULL);
+  ASSERT_TRUE(lm_ctrl_cloud_parse_dashboard_water_status(root, &water_status));
+  ASSERT_TRUE(water_status.available);
+  ASSERT_TRUE(water_status.no_water);
+
+  cJSON_Delete(root);
+  return 0;
+}
+
 static int test_parse_dashboard_values_extracts_machine_and_bbw_state(void) {
   static const char *response_body =
     "{"
@@ -353,6 +366,7 @@ int run_cloud_api_tests(void) {
   RUN_TEST(test_parse_access_token_success_and_invalid_payload);
   RUN_TEST(test_parse_customer_fleet_filters_invalid_entries);
   RUN_TEST(test_parse_dashboard_machine_status_extracts_online_signal);
+  RUN_TEST(test_parse_dashboard_water_status_extracts_no_water_alarm);
   RUN_TEST(test_parse_dashboard_values_extracts_machine_and_bbw_state);
   RUN_TEST(test_parse_dashboard_values_uses_brewing_status_without_timestamp);
   RUN_TEST(test_parse_dashboard_values_does_not_treat_brewing_mode_as_live_shot_by_itself);


### PR DESCRIPTION
## What changed

This updates the ESP32 firmware around cloud connectivity, warmup timing, and machine water-state visibility.

- adds extra setup-portal diagnostics for cloud probe, HTTP in-flight work, websocket transport, websocket subscription, and machine cloud online state
- fixes warmup ETA handling when dashboard data comes from the cloud websocket by setting a usable observed timestamp and guarding against bogus local epoch time
- re-arms heat refresh polling when heating is active but ETA is still not usable
- adds machine water alarm state plumbing from both cloud dashboard `CMNoWater` and BLE `tankStatus`
- shows a blue water-drop icon in the top info bar when the machine reports no water
- replaces the generic main-screen hint with a specific German/English no-water warning, including the umlaut fix for `prüfen` / `füllen`
- adds a host test for cloud `CMNoWater` parsing

## Why

Two issues showed up while debugging live cloud websocket behavior:

1. warmup ETA regressed after websocket activation because the websocket path did not attach a usable observation time the same way the REST path did
2. the machine could enter a no-water state that was visible in live diagnostics but not clearly surfaced in the controller UI

The BLE `tankStatus` path is included so the warning does not depend only on cloud widget availability.

## Impact

- warmup ETA should stay stable after websocket activation
- users get an explicit top-bar warning and clearer text when the machine reports no water
- setup portal diagnostics make websocket startup and cloud wait states easier to understand

## Validation

- `./dev.sh test`
- `./dev.sh build`

## Notes

The final umlaut text fix is included in this branch and builds cleanly. It was not re-verified on-device because the USB serial port dropped after reset during the last flash attempt.