### PR TITLE
[codex] Fix ESP-IDF 5.5 Windows build

### DIFF
--- a/docs/controller/FLASHING_CONTROLLER.md
+++ b/docs/controller/FLASHING_CONTROLLER.md
@@ -14,7 +14,7 @@ This repository currently supports two documented flashing paths:
 - a USB data cable
 - Python 3.10 or newer
 - `git`
-- an installed ESP-IDF toolchain
+- ESP-IDF 5.5 or newer
 - the controller board connected over USB
 
 ## 2. macOS / Linux
@@ -24,9 +24,9 @@ This repository currently supports two documented flashing paths:
 If ESP-IDF is not installed yet on macOS or Linux:
 
 ```bash
-git clone --recursive https://github.com/espressif/esp-idf.git ~/esp/esp-idf
+git clone -b v5.5 --recursive https://github.com/espressif/esp-idf.git ~/esp/esp-idf
 cd ~/esp/esp-idf
-./install.sh esp32,esp32s3
+./install.sh esp32s3
 ```
 
 In every new shell session, load the environment first:
@@ -108,13 +108,26 @@ The hook runs `./firmware/esp32/dev.sh test` from the repository root. On a fres
 
 On Windows, use Espressif's official installer and ESP-IDF terminal instead of `dev.sh`:
 
-- [ESP-IDF Windows setup](https://docs.espressif.com/projects/esp-idf/en/release-v5.4/esp32s3/get-started/windows-setup.html)
-- [ESP-IDF start project on Windows](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/get-started/windows-start-project.html)
+- [ESP-IDF Windows setup](https://docs.espressif.com/projects/esp-idf/en/release-v5.5/esp32s3/get-started/windows-setup.html)
+- [ESP-IDF start project on Windows](https://docs.espressif.com/projects/esp-idf/en/release-v5.5/esp32s3/get-started/windows-start-project.html)
 
 Use a project path without spaces, for example:
 
 ```text
 C:\dev\lamarzocco
+```
+
+The firmware component manifest requires ESP-IDF `>=5.5.0`. ESP-IDF 5.4 is no
+longer a supported build target for this repository.
+
+If installing ESP-IDF from Git instead of the installer, clone the stable 5.5
+branch and export the environment before building:
+
+```powershell
+git clone -b v5.5 --recursive https://github.com/espressif/esp-idf.git C:\esp-idf
+cd C:\esp-idf
+.\install.ps1 esp32s3
+.\export.ps1
 ```
 
 ### First flash

--- a/docs/controller/FLASHING_CONTROLLER.md
+++ b/docs/controller/FLASHING_CONTROLLER.md
@@ -24,7 +24,7 @@ This repository currently supports two documented flashing paths:
 If ESP-IDF is not installed yet on macOS or Linux:
 
 ```bash
-git clone -b v5.5 --recursive https://github.com/espressif/esp-idf.git ~/esp/esp-idf
+git clone -b release/v5.5 --recursive https://github.com/espressif/esp-idf.git ~/esp/esp-idf
 cd ~/esp/esp-idf
 ./install.sh esp32s3
 ```
@@ -124,7 +124,7 @@ If installing ESP-IDF from Git instead of the installer, clone the stable 5.5
 branch and export the environment before building:
 
 ```powershell
-git clone -b v5.5 --recursive https://github.com/espressif/esp-idf.git C:\esp-idf
+git clone -b release/v5.5 --recursive https://github.com/espressif/esp-idf.git C:\esp-idf
 cd C:\esp-idf
 .\install.ps1 esp32s3
 .\export.ps1

--- a/firmware/esp32/README.md
+++ b/firmware/esp32/README.md
@@ -241,6 +241,9 @@ Additional module notes:
 
 `dev.sh` is the local Bash helper for macOS/Linux. Native Windows flashing is documented through the standard ESP-IDF terminal flow in `docs/controller/FLASHING_CONTROLLER.md`.
 
+The firmware requires ESP-IDF 5.5 or newer. ESP-IDF 5.4 is no longer supported
+because the managed component set requires `idf >=5.5.0`.
+
 ### macOS / Linux
 
 ```bash
@@ -288,6 +291,7 @@ Use the native ESP-IDF Windows environment and flash with:
 ```powershell
 cd C:\dev\lamarzocco\firmware\esp32
 idf.py set-target esp32s3
+idf.py build
 idf.py -p COM5 flash monitor
 ```
 

--- a/firmware/esp32/README.md
+++ b/firmware/esp32/README.md
@@ -243,6 +243,8 @@ Additional module notes:
 
 The firmware requires ESP-IDF 5.5 or newer. ESP-IDF 5.4 is no longer supported
 because the managed component set requires `idf >=5.5.0`.
+The WebSocket component is constrained below 1.6.0 because the 1.6.x redirect
+support expects transport APIs that are not present in all ESP-IDF 5.5 installs.
 
 ### macOS / Linux
 

--- a/firmware/esp32/main/cloud_api.c
+++ b/firmware/esp32/main/cloud_api.c
@@ -22,7 +22,21 @@
 #include "lm_ctrl_secure_utils.h"
 #include "mbedtls/base64.h"
 #include "mbedtls/pk.h"
+#if defined(__has_include)
+#if __has_include("mbedtls/build_info.h")
+#include "mbedtls/build_info.h"
+#endif
+#if __has_include("mbedtls/sha256.h")
+#include "mbedtls/sha256.h"
+#else
 #include "mbedtls/private/sha256.h"
+#endif
+#else
+#include "mbedtls/sha256.h"
+#endif
+#if defined(MBEDTLS_VERSION_MAJOR) && MBEDTLS_VERSION_MAJOR == 3
+#include "mbedtls/ecp.h"
+#endif
 #include "machine_link_types.h"
 #include "psa/crypto.h"
 
@@ -118,6 +132,100 @@ static esp_err_t sha256_bytes(const uint8_t *data, size_t data_len, uint8_t outp
   }
 
   return mbedtls_sha256(data, data_len, output, 0) == 0 ? ESP_OK : ESP_FAIL;
+}
+
+#if defined(MBEDTLS_VERSION_MAJOR) && MBEDTLS_VERSION_MAJOR == 3
+static int mbedtls_rng_fill(void *ctx, unsigned char *output, size_t output_len) {
+  (void)ctx;
+
+  if (output == NULL) {
+    return -1;
+  }
+
+  esp_fill_random(output, output_len);
+  return 0;
+}
+#endif
+
+static int parse_private_key_der(mbedtls_pk_context *pk, const uint8_t *private_key_der, size_t private_key_der_len) {
+#if defined(MBEDTLS_VERSION_MAJOR) && MBEDTLS_VERSION_MAJOR == 3
+  return mbedtls_pk_parse_key(pk, private_key_der, private_key_der_len, NULL, 0, mbedtls_rng_fill, NULL);
+#else
+  return mbedtls_pk_parse_key(pk, private_key_der, private_key_der_len, NULL, 0);
+#endif
+}
+
+static int sign_hash_der(
+  mbedtls_pk_context *pk,
+  const uint8_t hash[32],
+  unsigned char *signature_der,
+  size_t signature_der_size,
+  size_t *signature_der_len
+) {
+#if defined(MBEDTLS_VERSION_MAJOR) && MBEDTLS_VERSION_MAJOR == 3
+  return mbedtls_pk_sign(
+    pk,
+    MBEDTLS_MD_SHA256,
+    hash,
+    32,
+    signature_der,
+    signature_der_size,
+    signature_der_len,
+    mbedtls_rng_fill,
+    NULL
+  );
+#else
+  return mbedtls_pk_sign(
+    pk,
+    MBEDTLS_MD_SHA256,
+    hash,
+    32,
+    signature_der,
+    signature_der_size,
+    signature_der_len
+  );
+#endif
+}
+
+static esp_err_t generate_ec_key_pair(mbedtls_pk_context *pk, psa_key_id_t *key_id, psa_key_attributes_t *key_attributes) {
+#if defined(MBEDTLS_VERSION_MAJOR) && MBEDTLS_VERSION_MAJOR == 3
+  const mbedtls_pk_info_t *pk_info;
+
+  (void)key_id;
+  (void)key_attributes;
+
+  pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY);
+  if (pk_info == NULL || mbedtls_pk_setup(pk, pk_info) != 0) {
+    return ESP_FAIL;
+  }
+  if (mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, mbedtls_pk_ec(*pk), mbedtls_rng_fill, NULL) != 0) {
+    return ESP_FAIL;
+  }
+
+  return ESP_OK;
+#else
+  psa_status_t psa_status = PSA_SUCCESS;
+
+  psa_status = psa_crypto_init();
+  if (psa_status != PSA_SUCCESS) {
+    return ESP_FAIL;
+  }
+
+  psa_set_key_usage_flags(key_attributes, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_SIGN_HASH);
+  psa_set_key_algorithm(key_attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
+  psa_set_key_type(key_attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
+  psa_set_key_bits(key_attributes, 256);
+
+  psa_status = psa_generate_key(key_attributes, key_id);
+  if (psa_status != PSA_SUCCESS) {
+    return ESP_FAIL;
+  }
+  if (mbedtls_pk_wrap_psa(pk, *key_id) != 0) {
+    return ESP_FAIL;
+  }
+
+  return ESP_OK;
+#endif
 }
 
 static esp_err_t base64_encode_bytes(const uint8_t *data, size_t data_len, char *output, size_t output_size) {
@@ -224,7 +332,6 @@ esp_err_t lm_ctrl_cloud_generate_installation(lm_ctrl_cloud_installation_t *inst
   const unsigned char *public_key_ptr;
   int private_key_der_len = 0;
   int public_key_der_len = 0;
-  psa_status_t psa_status = PSA_SUCCESS;
   esp_err_t ret = ESP_FAIL;
 
   if (installation == NULL) {
@@ -234,24 +341,8 @@ esp_err_t lm_ctrl_cloud_generate_installation(lm_ctrl_cloud_installation_t *inst
   memset(installation, 0, sizeof(*installation));
   format_uuid_v4(installation->installation_id);
 
-  psa_status = psa_crypto_init();
-  if (psa_status != PSA_SUCCESS) {
-    ret = ESP_FAIL;
-    goto exit;
-  }
-
   mbedtls_pk_init(&pk);
-  psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_SIGN_HASH);
-  psa_set_key_algorithm(&key_attributes, PSA_ALG_ECDSA(PSA_ALG_SHA_256));
-  psa_set_key_type(&key_attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
-  psa_set_key_bits(&key_attributes, 256);
-
-  psa_status = psa_generate_key(&key_attributes, &key_id);
-  if (psa_status != PSA_SUCCESS) {
-    ret = ESP_FAIL;
-    goto exit;
-  }
-  if (mbedtls_pk_wrap_psa(&pk, key_id) != 0) {
+  if (generate_ec_key_pair(&pk, &key_id, &key_attributes) != ESP_OK) {
     ret = ESP_FAIL;
     goto exit;
   }
@@ -279,7 +370,9 @@ esp_err_t lm_ctrl_cloud_generate_installation(lm_ctrl_cloud_installation_t *inst
   );
 
 exit:
+#if !defined(MBEDTLS_VERSION_MAJOR) || MBEDTLS_VERSION_MAJOR != 3
   psa_reset_key_attributes(&key_attributes);
+#endif
   mbedtls_pk_free(&pk);
   if (key_id != 0) {
     (void)psa_destroy_key(key_id);
@@ -395,7 +488,7 @@ esp_err_t lm_ctrl_cloud_derive_installation_material(
   }
 
   mbedtls_pk_init(&pk);
-  if (mbedtls_pk_parse_key(&pk, private_key_der, private_key_der_len, NULL, 0) != 0) {
+  if (parse_private_key_der(&pk, private_key_der, private_key_der_len) != 0) {
     mbedtls_pk_free(&pk);
     return ESP_FAIL;
   }
@@ -598,19 +691,11 @@ esp_err_t lm_ctrl_cloud_build_signed_request_headers(
   }
 
   mbedtls_pk_init(&pk);
-  if (mbedtls_pk_parse_key(&pk, installation->private_key_der, installation->private_key_der_len, NULL, 0) != 0) {
+  if (parse_private_key_der(&pk, installation->private_key_der, installation->private_key_der_len) != 0) {
     mbedtls_pk_free(&pk);
     return ESP_FAIL;
   }
-  if (mbedtls_pk_sign(
-        &pk,
-        MBEDTLS_MD_SHA256,
-        signature_hash,
-        sizeof(signature_hash),
-        signature_der,
-        sizeof(signature_der),
-        &signature_der_len
-      ) != 0) {
+  if (sign_hash_der(&pk, signature_hash, signature_der, sizeof(signature_der), &signature_der_len) != 0) {
     mbedtls_pk_free(&pk);
     return ESP_FAIL;
   }

--- a/firmware/esp32/main/idf_component.yml
+++ b/firmware/esp32/main/idf_component.yml
@@ -10,4 +10,4 @@ dependencies:
   espressif/cjson: ^1.7.19~1
   espressif/mdns: ^1.10.1
   espressif/led_strip: ^3.0.1
-  espressif/esp_websocket_client: ^1.2.2
+  espressif/esp_websocket_client: ">=1.2.2,<1.6.0"


### PR DESCRIPTION
## Summary

Fix the ESP-IDF 5.5 Windows build for the ESP32 firmware.

The original failure came from ESP-IDF 5.5 using mbedTLS 3 APIs while `cloud_api.c` still mixed in newer/private mbedTLS and PSA paths. The firmware now uses the public SHA-256 header where available, calls the mbedTLS 3 `pk_parse_key` and `pk_sign` APIs with RNG parameters, and generates the EC key through the mbedTLS 3 EC key path while keeping the existing PSA path for newer local builds.

This also documents ESP-IDF 5.5 as the minimum supported version and constrains `espressif/esp_websocket_client` below 1.6.0. The 1.6.x redirect support expects a transport API that is not present in all ESP-IDF 5.5 installs, and this firmware does not rely on that redirect feature.

## Validation

- `firmware/esp32/tests/host/run.sh`
- local ESP-IDF firmware build
- Windows 11 in Parallels with ESP-IDF 5.5: `idf.py -B build-idf55 build` completed successfully